### PR TITLE
把默认并发和队列调大一点，减少 Telegram 高峰期阻塞

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ chmod +x install.sh && ./install.sh
 - ✅ 创建全量 Agent Workspace（含太子/吏部/早朝，兼容历史 main）
 - ✅ 写入各省部 SOUL.md（角色人格 + 工作流规则 + 数据清洗规范）
 - ✅ 注册 Agent 及权限矩阵到 `openclaw.json`
+- ✅ 预置消息队列扩容参数（Telegram 高峰更顺畅，减少卡住）
 - ✅ 构建 React 前端（需 Node.js 18+，如未安装则跳过）
 - ✅ 初始化数据目录 + 首次数据同步
 - ✅ 重启 Gateway 使配置生效

--- a/README_EN.md
+++ b/README_EN.md
@@ -203,6 +203,7 @@ The installer automatically:
 - Creates workspaces for all departments (`~/.openclaw/workspace-*`, including Crown Prince/HR/Briefing)
 - Writes SOUL.md personality files for each department
 - Registers agents + permission matrix in `openclaw.json`
+- Applies queue/concurrency defaults for smoother Telegram burst handling
 - Initializes data directory + first sync
 - Restarts Gateway
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,6 +34,7 @@ chmod +x install.sh && ./install.sh
 - ✅ 创建 12 个 Agent Workspace（`~/.openclaw/workspace-*`）
 - ✅ 写入各省部 SOUL.md 人格文件
 - ✅ 注册 Agent 及权限矩阵到 `openclaw.json`
+- ✅ 预置消息队列扩容参数（提升 Telegram 高峰稳定性）
 - ✅ 配置旨意数据清洗规则
 - ✅ 构建 React 前端到 `dashboard/dist/`（需 Node.js 18+）
 - ✅ 初始化数据目录

--- a/install.sh
+++ b/install.sh
@@ -165,6 +165,31 @@ for ag in AGENTS:
         print(f'  ~ exists: {ag_id} (skipped)')
 
 agents_cfg['list'] = agents_list
+
+# Widen runtime throughput defaults for multi-agent bursts.
+# Keep user customizations when they are already higher.
+agent_defaults = agents_cfg.setdefault('defaults', {})
+current_max = agent_defaults.get('maxConcurrent')
+if not isinstance(current_max, int) or current_max < 8:
+    agent_defaults['maxConcurrent'] = 8
+    print('  ~ agents.defaults.maxConcurrent => 8')
+
+sub_cfg = agent_defaults.setdefault('subagents', {})
+sub_max = sub_cfg.get('maxConcurrent')
+if not isinstance(sub_max, int) or sub_max < 16:
+    sub_cfg['maxConcurrent'] = 16
+    print('  ~ agents.defaults.subagents.maxConcurrent => 16')
+
+messages_cfg = cfg.setdefault('messages', {})
+queue_cfg = messages_cfg.setdefault('queue', {})
+queue_cfg['mode'] = 'steer-backlog'
+queue_cfg.setdefault('byChannel', {})['telegram'] = 'steer-backlog'
+queue_cfg['debounceMs'] = 300
+queue_cfg.setdefault('debounceMsByChannel', {})['telegram'] = 300
+queue_cfg['cap'] = 60
+queue_cfg['drop'] = 'summarize'
+print('  ~ messages.queue tuned for telegram bursts')
+
 cfg_path.write_text(json.dumps(cfg, ensure_ascii=False, indent=2))
 print(f'Done: {added} agents added')
 PYEOF


### PR DESCRIPTION
这次主要是把默认参数调得更抗压一点，核心目标就是“多一点并发，少一点卡住”。
具体做了这几件事：
- agent 并发上调：maxConcurrent 最低 8，subagents.maxConcurrent 最低 16
- 消息队列改成更适合高峰的模式：steer-backlog
-  - Telegram 队列参数预置：debounce 300ms、cap 60、drop summarize
- 文档补了一句：安装后默认就是这套更顺滑的配置

效果上就是：群里消息一多时，响应会更稳，不容易堆死。