### PR TITLE
fix: kanban_update.py 相对路径导致多 Agent 数据孤岛问题

### DIFF
--- a/scripts/kanban_update.py
+++ b/scripts/kanban_update.py
@@ -24,7 +24,9 @@
 """
 import json, pathlib, datetime, sys, subprocess, logging, os, re
 
-_BASE = pathlib.Path(__file__).resolve().parent.parent
+# 优先使用环境变量 EDICT_HOME，兜底才用脚本相对路径
+# 这样脚本被 sync 到各 workspace 后仍能正确写入中央数据库
+_BASE = pathlib.Path(os.environ['EDICT_HOME']) if 'EDICT_HOME' in os.environ else pathlib.Path(__file__).resolve().parent.parent
 TASKS_FILE = _BASE / 'data' / 'tasks_source.json'
 REFRESH_SCRIPT = _BASE / 'scripts' / 'refresh_live_data.py'
 

--- a/scripts/run_loop.sh
+++ b/scripts/run_loop.sh
@@ -5,6 +5,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# EDICT_HOME 指向中央仓库根目录，供各 workspace 里的 kanban_update.py 定位中央数据库
+export EDICT_HOME="$(dirname "$SCRIPT_DIR")"
 INTERVAL="${1:-15}"
 LOG="/tmp/sansheng_liubu_refresh.log"
 PIDFILE="/tmp/sansheng_liubu_refresh.pid"


### PR DESCRIPTION
## 问题描述

按官方 `install.sh` 标准流程部署后，启动多 Agent 实际协同时，子 Agent 无法将任务数据写入中央看板，导致 `tasks_source.json` 数据断连、看板全部瘫痪。

## 根本原因

`sync_agent_config.py` 中的 `sync_scripts_to_workspaces()` 函数会将 `scripts/` 目录下所有脚本**物理复制**到 11 个 Agent 的私有 workspace（`~/.openclaw/workspace-*/scripts/`）。

但 `kanban_update.py` 第 27 行使用的是相对路径：

```python
_BASE = pathlib.Path(__file__).resolve().parent.parent
```

- 脚本在源仓库运行时：`__file__` 上两级 = `edict-sansheng/` ✅ 正确  
- 脚本被复制到 `workspace-taizi/scripts/` 后：`__file__` 上两级 = `workspace-taizi/` ❌ 错误

结果：11 个 Agent 各自在私有目录里创建 `data/tasks_source.json`，形成**数据孤岛**，中央看板完全断连。任何按官方流程部署的用户都会遇到此问题。

## 修复方案

### `scripts/kanban_update.py`
优先读取环境变量 `EDICT_HOME` 定位中央仓库，没有才 fallback 到相对路径（保持向后兼容）：

```python
_BASE = pathlib.Path(os.environ['EDICT_HOME']) if 'EDICT_HOME' in os.environ else pathlib.Path(__file__).resolve().parent.parent
```

### `scripts/run_loop.sh`
启动时自动 export `EDICT_HOME`，所有子进程继承：

```bash
export EDICT_HOME="$(dirname "$SCRIPT_DIR")"
```

## 影响范围
- 仅 2 个文件各增加 2-3 行，修改最小化
- 完全向后兼容：未设置 `EDICT_HOME` 时行为与原版一致
- 修复后 `sync_agent_config.py` 重新分发脚本时，分发的即为修复版本，永久生效