### PR TITLE
修复看板日志不可见：自动选择正确任务数据源（多工作区）

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -38,6 +38,7 @@ BASE = pathlib.Path(__file__).parent
 DIST = BASE / 'dist'          # React 构建产物 (npm run build)
 DATA = BASE.parent / "data"
 SCRIPTS = BASE.parent / 'scripts'
+_ACTIVE_TASK_DATA_DIR = None
 
 # 静态资源 MIME 类型
 _MIME_TYPES = {
@@ -82,19 +83,82 @@ def now_iso():
     return datetime.datetime.now(datetime.timezone.utc).isoformat().replace('+00:00', 'Z')
 
 
+def _iter_task_data_dirs():
+    """返回可用的任务数据目录候选（优先 workspace，其次本地 data）。"""
+    dirs = [DATA]
+    oclaw_home = pathlib.Path.home() / '.openclaw'
+    for p in sorted(oclaw_home.glob('workspace-*/data')):
+        if p.is_dir():
+            dirs.append(p)
+    return dirs
+
+
+def _task_source_score(task_file: pathlib.Path):
+    """给任务源打分：优先非 demo 任务，其次任务数，再按文件更新时间。"""
+    try:
+        tasks = atomic_json_read(task_file, [])
+    except Exception:
+        tasks = []
+    if not isinstance(tasks, list):
+        tasks = []
+    non_demo = 0
+    for t in tasks:
+        tid = str((t or {}).get('id', ''))
+        if tid and not tid.startswith('JJC-DEMO'):
+            non_demo += 1
+    try:
+        mtime = task_file.stat().st_mtime
+    except Exception:
+        mtime = 0
+    return (1 if non_demo > 0 else 0, non_demo, len(tasks), mtime)
+
+
+def get_task_data_dir():
+    """自动选择当前任务数据目录，并缓存结果以保持一次服务期内稳定。"""
+    global _ACTIVE_TASK_DATA_DIR
+    if _ACTIVE_TASK_DATA_DIR and _ACTIVE_TASK_DATA_DIR.is_dir():
+        return _ACTIVE_TASK_DATA_DIR
+
+    best_dir = DATA
+    best_score = (-1, -1, -1, -1)
+    for d in _iter_task_data_dirs():
+        tf = d / 'tasks_source.json'
+        if not tf.exists():
+            continue
+        score = _task_source_score(tf)
+        if score > best_score:
+            best_score = score
+            best_dir = d
+
+    _ACTIVE_TASK_DATA_DIR = best_dir
+    log.info(f'任务数据源: {_ACTIVE_TASK_DATA_DIR}')
+    return _ACTIVE_TASK_DATA_DIR
+
+
+def _refresh_live_data_async(task_data_dir: pathlib.Path):
+    """触发对应数据目录的 live_status 刷新脚本。"""
+    script = task_data_dir.parent / 'scripts' / 'refresh_live_data.py'
+    if not script.exists():
+        script = SCRIPTS / 'refresh_live_data.py'
+
+    def _refresh():
+        try:
+            subprocess.run(['python3', str(script)], timeout=30)
+        except Exception as e:
+            log.warning(f'refresh_live_data.py 触发失败: {e}')
+
+    threading.Thread(target=_refresh, daemon=True).start()
+
+
 def load_tasks():
-    return atomic_json_read(DATA / 'tasks_source.json', [])
+    task_data_dir = get_task_data_dir()
+    return atomic_json_read(task_data_dir / 'tasks_source.json', [])
 
 
 def save_tasks(tasks):
-    atomic_json_write(DATA / 'tasks_source.json', tasks)
-    # Trigger refresh (异步，不阻塞，避免僵尸进程)
-    def _refresh():
-        try:
-            subprocess.run(['python3', str(SCRIPTS / 'refresh_live_data.py')], timeout=30)
-        except Exception as e:
-            log.warning(f'refresh_live_data.py 触发失败: {e}')
-    threading.Thread(target=_refresh, daemon=True).start()
+    task_data_dir = get_task_data_dir()
+    atomic_json_write(task_data_dir / 'tasks_source.json', tasks)
+    _refresh_live_data_async(task_data_dir)
 
 
 def handle_task_action(task_id, action, reason):
@@ -2124,12 +2188,17 @@ class Handler(BaseHTTPRequestHandler):
         if p in ('', '/dashboard', '/dashboard.html'):
             self.send_file(DIST / 'index.html')
         elif p == '/healthz':
-            checks = {'dataDir': DATA.is_dir(), 'tasksReadable': (DATA / 'tasks_source.json').exists()}
-            checks['dataWritable'] = os.access(str(DATA), os.W_OK)
+            task_data_dir = get_task_data_dir()
+            checks = {
+                'dataDir': task_data_dir.is_dir(),
+                'tasksReadable': (task_data_dir / 'tasks_source.json').exists(),
+            }
+            checks['dataWritable'] = os.access(str(task_data_dir), os.W_OK)
             all_ok = all(checks.values())
             self.send_json({'status': 'ok' if all_ok else 'degraded', 'ts': now_iso(), 'checks': checks})
         elif p == '/api/live-status':
-            self.send_json(read_json(DATA / 'live_status.json'))
+            task_data_dir = get_task_data_dir()
+            self.send_json(read_json(task_data_dir / 'live_status.json'))
         elif p == '/api/agent-config':
             self.send_json(read_json(DATA / 'agent_config.json'))
         elif p == '/api/model-change-log':


### PR DESCRIPTION
## 问题现象
在多工作区场景下，看板页面只能看到初始化任务 `JJC-DEMO-001`，但实际已经生成并完成的旨意（例如 `JJC-20260311-004`）及其日志不会显示。

## 根因分析
`dashboard/server.py` 原先固定读取：
- `edict/data/tasks_source.json`
- `edict/data/live_status.json`

而实际运行时，任务数据可能写入到：
- `~/.openclaw/workspace-*/data/tasks_source.json`
- `~/.openclaw/workspace-*/data/live_status.json`

导致看板读取源与运行时写入源不一致，出现“任务已完成但看板看不到”的问题。

## 修复内容
本 PR 在 `dashboard/server.py` 中做了以下修复：

1. 新增任务数据目录自动探测
- 候选目录包括：
  - `edict/data`
  - `~/.openclaw/workspace-*/data`

2. 新增数据源评分与选择策略
- 优先选择包含非 DEMO 任务的数据源
- 其次按任务数量与文件更新时间进行排序
- 服务运行期间缓存所选目录，保证读写一致

3. 统一任务读写与状态读取路径
- `load_tasks()` 使用自动选中的数据目录
- `save_tasks()` 写回同一目录
- `/api/live-status` 从同一目录读取 `live_status.json`

4. 刷新逻辑与健康检查同步修正
- 刷新优先调用所选数据源对应的 `scripts/refresh_live_data.py`
- `/healthz` 改为检查当前活跃数据目录的可读写状态

## 验证结果
已完成以下验证：

- 语法检查通过：
  - `python3 -m py_compile dashboard/server.py`

- 运行时数据源选择正确：
  - 自动选择目录：`/home/zhaoc/.openclaw/workspace-taizi/data`

- 任务与看板状态一致：
  - `tasks_source` 可见任务：`JJC-20260311-004`, `JJC-20260311-003`
  - `live_status` 可见任务：`JJC-20260311-004`, `JJC-20260311-003`

## 影响范围
- 修复多工作区部署中看板任务与日志缺失的问题
- 不改变单目录部署的既有行为
- 降低“看板与实际执行状态不一致”的运维风险
