### PR TITLE
fix(scripts): resolve kanban_update.py data path to canonical repo location

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,6 +107,13 @@ create_workspaces() {
     log "Workspace 已创建: $ws"
   done
 
+  # 写入 EDICT_REPO_DIR 环境变量（供 kanban_update.py 等脚本定位数据目录）
+  for agent in "${AGENTS[@]}"; do
+    ws="$OC_HOME/workspace-$agent"
+    echo "EDICT_REPO_DIR=$REPO_DIR" > "$ws/.env"
+  done
+  log "EDICT_REPO_DIR 已写入所有 workspace/.env"
+
   # 通用 AGENTS.md（工作协议）
   for agent in "${AGENTS[@]}"; do
     cat > "$OC_HOME/workspace-$agent/AGENTS.md" << 'AGENTS_EOF'

--- a/scripts/kanban_update.py
+++ b/scripts/kanban_update.py
@@ -24,7 +24,36 @@
 """
 import json, pathlib, sys, subprocess, logging, os, re
 
-_BASE = pathlib.Path(__file__).resolve().parent.parent
+
+def _find_repo_root():
+    """Resolve the canonical repo root directory.
+
+    Priority:
+    1. EDICT_REPO_DIR environment variable (set by install.sh)
+    2. Walk up from __file__ looking for .git or dashboard/ as repo markers
+    3. Fall back to __file__-based parent (original behavior)
+    """
+    env_dir = os.environ.get('EDICT_REPO_DIR', '').strip()
+    if env_dir:
+        p = pathlib.Path(env_dir)
+        if p.is_dir():
+            return p
+
+    # Walk up from script location looking for repo markers
+    candidate = pathlib.Path(__file__).resolve().parent.parent
+    for _ in range(5):
+        if (candidate / '.git').exists() or (candidate / 'dashboard').is_dir():
+            return candidate
+        parent = candidate.parent
+        if parent == candidate:
+            break
+        candidate = parent
+
+    # Fall back to original behavior
+    return pathlib.Path(__file__).resolve().parent.parent
+
+
+_BASE = _find_repo_root()
 TASKS_FILE = _BASE / 'data' / 'tasks_source.json'
 REFRESH_SCRIPT = _BASE / 'scripts' / 'refresh_live_data.py'
 

--- a/scripts/refresh_live_data.py
+++ b/scripts/refresh_live_data.py
@@ -1,12 +1,39 @@
 #!/usr/bin/env python3
-import json, pathlib, datetime, logging
+import json, pathlib, datetime, logging, os
 from file_lock import atomic_json_write, atomic_json_read
 from utils import read_json
 
 log = logging.getLogger('refresh')
 logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(name)s] %(message)s', datefmt='%H:%M:%S')
 
-BASE = pathlib.Path(__file__).parent.parent
+
+def _find_repo_root():
+    """Resolve the canonical repo root directory.
+
+    Priority:
+    1. EDICT_REPO_DIR environment variable (set by install.sh)
+    2. Walk up from __file__ looking for .git or dashboard/ as repo markers
+    3. Fall back to __file__-based parent (original behavior)
+    """
+    env_dir = os.environ.get('EDICT_REPO_DIR', '').strip()
+    if env_dir:
+        p = pathlib.Path(env_dir)
+        if p.is_dir():
+            return p
+
+    candidate = pathlib.Path(__file__).resolve().parent.parent
+    for _ in range(5):
+        if (candidate / '.git').exists() or (candidate / 'dashboard').is_dir():
+            return candidate
+        parent = candidate.parent
+        if parent == candidate:
+            break
+        candidate = parent
+
+    return pathlib.Path(__file__).resolve().parent.parent
+
+
+BASE = _find_repo_root()
 DATA = BASE / 'data'
 
 


### PR DESCRIPTION
## Summary

- Adds `_find_repo_root()` helper to `kanban_update.py` and `refresh_live_data.py` that resolves the canonical repo directory instead of relying on `__file__` location
- Resolution priority: `EDICT_REPO_DIR` env var > walk up from `__file__` looking for `.git` or `dashboard/` markers > original `__file__`-based fallback
- Updates `install.sh` to write `EDICT_REPO_DIR` to each workspace's `.env` file during installation

**Evidence:** Issue #56 reports that `kanban_update.py` writes to `~/.openclaw/workspace-*/data/tasks_source.json` (workspace copy) while the dashboard reads from `<repo>/data/tasks_source.json`. This data split makes agent status updates invisible to the dashboard. The existing `link_resources()` in `install.sh` creates symlinks as a mitigation, but the scripts themselves should resolve the correct path as a defense-in-depth measure.

Closes #56

## Test plan

- [ ] Set `EDICT_REPO_DIR=/path/to/edict` and run `python3 scripts/kanban_update.py state JJC-TEST Done "test"` from a workspace dir - verify it writes to repo's data/
- [ ] Without env var, run from repo root - verify `.git` marker is found and correct path is used
- [ ] Run `install.sh` and verify `.env` files are created in each workspace with `EDICT_REPO_DIR`