### PR TITLE
fix: 让 atomic_json_write 复用跨平台文件锁实现

### DIFF
--- a/scripts/file_lock.py
+++ b/scripts/file_lock.py
@@ -123,17 +123,17 @@ def atomic_json_write(path: pathlib.Path, data: Any) -> None:
     lock_file.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(str(lock_file), os.O_CREAT | os.O_RDWR)
     try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
+        _lock_exclusive(fd)
         tmp_fd, tmp_path = tempfile.mkstemp(
             dir=str(path.parent), suffix='.tmp', prefix=path.stem + '_'
         )
         try:
-            with os.fdopen(tmp_fd, 'w') as f:
+            with os.fdopen(tmp_fd, 'w', encoding='utf-8') as f:
                 json.dump(data, f, ensure_ascii=False, indent=2)
             os.replace(tmp_path, str(path))
         except Exception:
             os.unlink(tmp_path)
             raise
     finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
+        _unlock(fd)
         os.close(fd)


### PR DESCRIPTION
## 说明

这个 PR 只修复 `scripts/file_lock.py` 中 `atomic_json_write()` 的跨平台锁调用问题。

当前文件虽然已经定义了平台相关的锁实现：

- Unix-like：`fcntl`
- Windows：`msvcrt`

但 `atomic_json_write()` 之前仍然直接使用了平台特定调用，导致这层抽象没有被完整复用，也使得 Windows 下这条写入路径无法真正复用统一的跨平台实现。

---

## 修改内容

将 `atomic_json_write()` 中的锁调用统一为：

- `_lock_exclusive(fd)`
- `_unlock(fd)`

这样：

- 在 Linux/macOS 上仍然走 `fcntl`
- 在 Windows 上自动走 `msvcrt`

---

## 为什么这个改动适合单独合并

1. **改动范围小**
   - 只涉及 `scripts/file_lock.py`
   - 没有引入业务逻辑变化

2. **对 Unix-like 系统兼容**
   - Linux/macOS 仍然使用原有的 `fcntl` 逻辑
   - 只是让调用层真正回到已有的抽象接口

3. **对 Windows 生效**
   - 让 `atomic_json_write()` 这条路径真正具备跨平台能力

4. **便于独立审查**
   - 就算其他 Windows 兼容修复还需要继续讨论，这个点也可以作为一个低风险、小范围的基础修复先进入 `main`