### PR TITLE
fix: 修复 Windows 首次安装同步失败

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -34,9 +34,9 @@ function Check-Deps {
     }
     Log "OpenClaw CLI: OK"
 
-    $py = Get-Command python3 -ErrorAction SilentlyContinue
+    $py = Get-Command python -ErrorAction SilentlyContinue  #win环境优先 python，兼容first-sync脚本 
     if (-not $py) {
-        $py = Get-Command python -ErrorAction SilentlyContinue
+        $py = Get-Command python3 -ErrorAction SilentlyContinue
     }
     if (-not $py) {
         Error "未找到 python3 或 python"

--- a/scripts/sync_officials_stats.py
+++ b/scripts/sync_officials_stats.py
@@ -37,8 +37,10 @@ OFFICIALS = [
 ]
 
 def rj(p, d):
-    try: return json.loads(pathlib.Path(p).read_text())
-    except Exception: return d
+    try: 
+        return json.loads(pathlib.Path(p).read_text(encoding='utf-8'))
+    except Exception: 
+        return d
 
 
 # Pre-load openclaw config once (avoid re-reading per agent)


### PR DESCRIPTION
## 背景

在 Windows 环境下按仓库当前安装流程执行 `install.ps1` 时，首次安装后经常出现 First-Sync 未正确完成的问题，表现为：

- `data/agent_config.json` 为空或未正确生成
- `data/officials_stats.json` 未生成
- `data/live_status.json` 内容不完整或为空
- 终端看起来完成安装，但首次同步结果不正确

另外，在当前安装流程里，`scripts/sync_agent_config.py` 和 `install.ps1` 对 `workspace-*/scripts` 存在重复处理，容易导致后续脚本同步逻辑与目录链接逻辑冲突。

## 本 PR 修改

### 1. `install.ps1`
Windows 下优先使用 `python`，不再优先使用 `python3`。

原因：
在部分 Windows 环境中，`python3` 会解析到 `WindowsApps` 的启动别名，而不是实际可用的 Python 解释器，导致 First-Sync 阶段运行脚本异常或未正确执行。

### 2. `scripts/sync_agent_config.py`
注释掉 `sync_scripts_to_workspaces()` 调用。

原因：
`install.ps1` 已经在安装阶段将 `workspace-*/scripts` 连接到项目 `scripts` 目录，再执行逐文件 symlink 同步会形成重复处理。在 Windows 下这会带来明显冲突风险。

### 3. `scripts/sync_officials_stats.py`
读取 JSON 文件时显式使用 `encoding='utf-8'`。

原因：
否则在 Windows 环境中读取 `openclaw.json` 时可能因编码问题失败，并静默回退到默认模型值，导致 `officials_stats.json` 中所有官员模型错误显示为 `anthropic/claude-sonnet-4-6`。

## 结果

在本地 Windows 环境重新验证后：

- 第一次执行 `install.ps1` 可成功完成安装
- 手动执行 First-Sync 三个脚本可正常通过
- `agent_config.json`、`officials_stats.json`、`live_status.json` 可正常生成
- `officials_stats.json` 中模型信息可正确读取 `openclaw.json` 中的配置

## 说明

这个 PR 只包含与“Windows 首次安装同步失败”直接相关的 3 个最小修改，不包含其他额外功能调整。