### PR TITLE
Add sandbox install mode for taizi-only global setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,18 +295,41 @@ cd edict
 chmod +x install.sh && ./install.sh
 ```
 
+默认是 **全量安装模式**，会像以前一样把三省六部全部注册到全局 OpenClaw。
+
+如果你想使用 **沙箱安装模式**（推荐给已有 OpenClaw 主环境、只想让 `taizi` 对外可见的用户）：
+
+```bash
+chmod +x install.sh
+./install.sh --sandbox
+# 或：EDICT_INSTALL_MODE=sandbox ./install.sh
+```
+
+沙箱模式会：
+- 仅全局注册 `taizi`
+- 将其余省部放到 `~/.openclaw/workspaces/edict/agents/<agent>`
+- 将共享数据放到 `~/.openclaw/workspaces/edict/data`
+- 让看板优先读取沙箱 data/agents，而不是只依赖 `~/.openclaw/workspace-*`
+- 保持默认全量安装行为不变
+
+如需自定义沙箱根目录：
+
+```bash
+./install.sh --sandbox --sandbox-root ~/.openclaw/workspaces/my-edict
+```
+
 安装脚本自动完成：
-- ✅ 创建全量 Agent Workspace（含太子/吏部/早朝，兼容历史 main）
+- ✅ 创建 Agent Workspace（全量模式为全局 workspace；沙箱模式为 `taizi` 全局 + 其余省部沙箱化）
 - ✅ 写入各省部 SOUL.md（角色人格 + 工作流规则 + 数据清洗规范）
-- ✅ 注册 Agent 及权限矩阵到 `openclaw.json`
-- ✅ **符号链接统一数据**（各 Workspace 的 data/scripts → 项目目录，确保数据一致）
+- ✅ 注册 Agent 及权限矩阵到 `openclaw.json`（沙箱模式仅注册 `taizi`）
+- ✅ **符号链接统一数据**（全量模式链接到项目目录；沙箱模式链接到 `~/.openclaw/workspaces/edict/{data,scripts}`，确保数据一致）
 - ✅ **设置 Agent 间通信可见性**（`sessions.visibility all`，解决消息不可达问题）
 - ✅ **同步 API Key 到所有 Agent**（自动从已配置的 Agent 复制）
 - ✅ 构建 React 前端（需 Node.js 18+，如未安装则跳过）
 - ✅ 初始化数据目录 + 首次数据同步（含官员统计）
 - ✅ 重启 Gateway 使配置生效
 
-> ⚠️ **首次安装**：需先配置 API Key：`openclaw agents add taizi`，然后重新运行 `./install.sh` 同步到所有 Agent。
+> ⚠️ **首次安装**：需先配置 API Key：`openclaw agents add taizi`，然后重新运行 `./install.sh`。全量模式会同步到所有全局 Agent；沙箱模式只要求 `taizi` 全局可用。
 
 #### 启动
 

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -90,8 +90,11 @@ def cors_headers(h):
 
 
 def _iter_task_data_dirs():
-    """返回可用的任务数据目录候选（优先 workspace，其次本地 data）。"""
+    """返回可用的任务数据目录候选（优先 workspace/sandbox，其次本地 data）。"""
     dirs = [DATA]
+    sandbox_data = OCLAW_HOME / 'workspaces' / 'edict' / 'data'
+    if sandbox_data.is_dir():
+        dirs.append(sandbox_data)
     for p in sorted(OCLAW_HOME.glob('workspace-*/data')):
         if p.is_dir():
             dirs.append(p)

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,31 @@ set -e
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OC_HOME="$HOME/.openclaw"
 OC_CFG="$OC_HOME/openclaw.json"
+INSTALL_MODE="${EDICT_INSTALL_MODE:-full}"
+SANDBOX_NAME="${EDICT_SANDBOX_NAME:-edict}"
+SANDBOX_ROOT="$OC_HOME/workspaces/$SANDBOX_NAME"
+AGENTS=(taizi zhongshu menxia shangshu hubu libu bingbu xingbu gongbu libu_hr zaochao)
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --sandbox)
+      INSTALL_MODE="sandbox"
+      ;;
+    --full)
+      INSTALL_MODE="full"
+      ;;
+    --sandbox-root)
+      shift
+      SANDBOX_ROOT="$1"
+      ;;
+    --sync-auth)
+      SYNC_AUTH_ONLY=true
+      ;;
+    *)
+      ;;
+  esac
+  shift || true
+done
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
 
@@ -23,6 +48,31 @@ log()   { echo -e "${GREEN}✅ $1${NC}"; }
 warn()  { echo -e "${YELLOW}⚠️  $1${NC}"; }
 error() { echo -e "${RED}❌ $1${NC}"; }
 info()  { echo -e "${BLUE}ℹ️  $1${NC}"; }
+
+agent_workspace() {
+  local agent="$1"
+  if [ "$INSTALL_MODE" = "sandbox" ] && [ "$agent" != "taizi" ]; then
+    echo "$SANDBOX_ROOT/agents/$agent"
+  else
+    echo "$OC_HOME/workspace-$agent"
+  fi
+}
+
+shared_data_dir() {
+  if [ "$INSTALL_MODE" = "sandbox" ]; then
+    echo "$SANDBOX_ROOT/data"
+  else
+    echo "$REPO_DIR/data"
+  fi
+}
+
+shared_scripts_dir() {
+  if [ "$INSTALL_MODE" = "sandbox" ]; then
+    echo "$SANDBOX_ROOT/scripts"
+  else
+    echo "$REPO_DIR/scripts"
+  fi
+}
 
 # ── Step 0: 依赖检查 ──────────────────────────────────────────
 check_deps() {
@@ -92,9 +142,9 @@ backup_existing() {
 create_workspaces() {
   info "创建 Agent Workspace..."
   
-  AGENTS=(taizi zhongshu menxia shangshu hubu libu bingbu xingbu gongbu libu_hr zaochao)
+  [ "$INSTALL_MODE" = "sandbox" ] && mkdir -p "$SANDBOX_ROOT/agents"
   for agent in "${AGENTS[@]}"; do
-    ws="$OC_HOME/workspace-$agent"
+    ws="$(agent_workspace "$agent")"
     mkdir -p "$ws/skills"
     if [ -f "$REPO_DIR/agents/$agent/SOUL.md" ]; then
       if [ -f "$ws/SOUL.md" ]; then
@@ -109,7 +159,7 @@ create_workspaces() {
 
   # 通用 AGENTS.md（工作协议）
   for agent in "${AGENTS[@]}"; do
-    cat > "$OC_HOME/workspace-$agent/AGENTS.md" << 'AGENTS_EOF'
+    cat > "$(agent_workspace "$agent")/AGENTS.md" << 'AGENTS_EOF'
 # AGENTS.md · 工作协议
 
 1. 接到任务先回复"已接旨"。
@@ -128,34 +178,41 @@ register_agents() {
   cp "$OC_CFG" "$OC_CFG.bak.sansheng-$(date +%Y%m%d-%H%M%S)"
   log "已备份配置: $OC_CFG.bak.*"
 
-  python3 << 'PYEOF'
-import json, pathlib, sys
+  INSTALL_MODE="$INSTALL_MODE" SANDBOX_ROOT="$SANDBOX_ROOT" python3 << 'PYEOF'
+import json, os, pathlib
 
 cfg_path = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
 cfg = json.loads(cfg_path.read_text())
+install_mode = os.environ.get('INSTALL_MODE', 'full')
+sandbox_root = pathlib.Path(os.environ.get('SANDBOX_ROOT', str(pathlib.Path.home() / '.openclaw' / 'workspaces' / 'edict')))
 
-AGENTS = [
+all_agents = [
   {"id": "taizi",    "subagents": {"allowAgents": ["zhongshu"]}},
-    {"id": "zhongshu", "subagents": {"allowAgents": ["menxia", "shangshu"]}},
-    {"id": "menxia",   "subagents": {"allowAgents": ["shangshu", "zhongshu"]}},
+  {"id": "zhongshu", "subagents": {"allowAgents": ["menxia", "shangshu"]}},
+  {"id": "menxia",   "subagents": {"allowAgents": ["shangshu", "zhongshu"]}},
   {"id": "shangshu", "subagents": {"allowAgents": ["zhongshu", "menxia", "hubu", "libu", "bingbu", "xingbu", "gongbu", "libu_hr"]}},
-    {"id": "hubu",     "subagents": {"allowAgents": ["shangshu"]}},
-    {"id": "libu",     "subagents": {"allowAgents": ["shangshu"]}},
-    {"id": "bingbu",   "subagents": {"allowAgents": ["shangshu"]}},
-    {"id": "xingbu",   "subagents": {"allowAgents": ["shangshu"]}},
-    {"id": "gongbu",   "subagents": {"allowAgents": ["shangshu"]}},
+  {"id": "hubu",     "subagents": {"allowAgents": ["shangshu"]}},
+  {"id": "libu",     "subagents": {"allowAgents": ["shangshu"]}},
+  {"id": "bingbu",   "subagents": {"allowAgents": ["shangshu"]}},
+  {"id": "xingbu",   "subagents": {"allowAgents": ["shangshu"]}},
+  {"id": "gongbu",   "subagents": {"allowAgents": ["shangshu"]}},
   {"id": "libu_hr",  "subagents": {"allowAgents": ["shangshu"]}},
   {"id": "zaochao",  "subagents": {"allowAgents": []}},
 ]
+
+agents = [ag for ag in all_agents if install_mode != 'sandbox' or ag['id'] == 'taizi']
 
 agents_cfg = cfg.setdefault('agents', {})
 agents_list = agents_cfg.get('list', [])
 existing_ids = {a['id'] for a in agents_list}
 
 added = 0
-for ag in AGENTS:
+for ag in agents:
     ag_id = ag['id']
-    ws = str(pathlib.Path.home() / f'.openclaw/workspace-{ag_id}')
+    if install_mode == 'sandbox' and ag_id != 'taizi':
+        ws = str(sandbox_root / 'agents' / ag_id)
+    else:
+        ws = str(pathlib.Path.home() / f'.openclaw/workspace-{ag_id}')
     if ag_id not in existing_ids:
         entry = {'id': ag_id, 'workspace': ws, **{k:v for k,v in ag.items() if k!='id'}}
         agents_list.append(entry)
@@ -189,19 +246,20 @@ PYEOF
 init_data() {
   info "初始化数据目录..."
   
-  mkdir -p "$REPO_DIR/data"
+  DATA_DIR="$(shared_data_dir)"
+  mkdir -p "$DATA_DIR"
   
   # 初始化空文件
   for f in live_status.json agent_config.json model_change_log.json; do
-    if [ ! -f "$REPO_DIR/data/$f" ]; then
-      echo '{}' > "$REPO_DIR/data/$f"
+    if [ ! -f "$DATA_DIR/$f" ]; then
+      echo '{}' > "$DATA_DIR/$f"
     fi
   done
-  echo '[]' > "$REPO_DIR/data/pending_model_changes.json"
+  echo '[]' > "$DATA_DIR/pending_model_changes.json"
 
   # 初始任务文件
-  if [ ! -f "$REPO_DIR/data/tasks_source.json" ]; then
-    python3 << 'PYEOF'
+  if [ ! -f "$DATA_DIR/tasks_source.json" ]; then
+    DATA_DIR="$DATA_DIR" python3 << 'PYEOF'
 import json, pathlib
 tasks = [
     {
@@ -225,24 +283,33 @@ tasks = [
     }
 ]
 import os
-data_dir = pathlib.Path(os.environ.get('REPO_DIR', '.')) / 'data'
+data_dir = pathlib.Path(os.environ.get('DATA_DIR', '.'))
 data_dir.mkdir(exist_ok=True)
 (data_dir / 'tasks_source.json').write_text(json.dumps(tasks, ensure_ascii=False, indent=2))
 print('tasks_source.json 已初始化')
 PYEOF
   fi
 
-  log "数据目录初始化完成: $REPO_DIR/data"
+  log "数据目录初始化完成: $DATA_DIR"
 }
 
 # ── Step 3.3: 创建 data 软链接确保数据一致 (Fix #88) ─────────
 link_resources() {
   info "创建 data/scripts 软链接以确保 Agent 数据一致..."
   
-  AGENTS=(taizi zhongshu menxia shangshu hubu libu bingbu xingbu gongbu libu_hr zaochao)
+  DATA_DIR="$(shared_data_dir)"
+  SCRIPTS_DIR="$(shared_scripts_dir)"
+  [ "$INSTALL_MODE" = "sandbox" ] && mkdir -p "$SANDBOX_ROOT"
+  if [ "$INSTALL_MODE" = "sandbox" ]; then
+    mkdir -p "$DATA_DIR"
+    if [ ! -e "$SCRIPTS_DIR" ]; then
+      ln -s "$REPO_DIR/scripts" "$SCRIPTS_DIR"
+    fi
+  fi
+
   LINKED=0
   for agent in "${AGENTS[@]}"; do
-    ws="$OC_HOME/workspace-$agent"
+    ws="$(agent_workspace "$agent")"
     mkdir -p "$ws"
 
     # 软链接 data 目录：确保各 agent 读写同一份 tasks_source.json
@@ -252,10 +319,10 @@ link_resources() {
     elif [ -d "$ws_data" ]; then
       # 已有 data 目录（非符号链接），备份后替换
       mv "$ws_data" "${ws_data}.bak.$(date +%Y%m%d-%H%M%S)"
-      ln -s "$REPO_DIR/data" "$ws_data"
+      ln -s "$DATA_DIR" "$ws_data"
       LINKED=$((LINKED + 1))
     else
-      ln -s "$REPO_DIR/data" "$ws_data"
+      ln -s "$DATA_DIR" "$ws_data"
       LINKED=$((LINKED + 1))
     fi
 
@@ -265,10 +332,10 @@ link_resources() {
       : # 已是软链接
     elif [ -d "$ws_scripts" ]; then
       mv "$ws_scripts" "${ws_scripts}.bak.$(date +%Y%m%d-%H%M%S)"
-      ln -s "$REPO_DIR/scripts" "$ws_scripts"
+      ln -s "$SCRIPTS_DIR" "$ws_scripts"
       LINKED=$((LINKED + 1))
     else
-      ln -s "$REPO_DIR/scripts" "$ws_scripts"
+      ln -s "$SCRIPTS_DIR" "$ws_scripts"
       LINKED=$((LINKED + 1))
     fi
   done
@@ -280,7 +347,11 @@ link_resources() {
       link_path="$ws_main/$target"
       if [ ! -L "$link_path" ]; then
         [ -d "$link_path" ] && mv "$link_path" "${link_path}.bak.$(date +%Y%m%d-%H%M%S)"
-        ln -s "$REPO_DIR/$target" "$link_path"
+        if [ "$target" = "data" ]; then
+          ln -s "$DATA_DIR" "$link_path"
+        else
+          ln -s "$SCRIPTS_DIR" "$link_path"
+        fi
         LINKED=$((LINKED + 1))
       fi
     done
@@ -346,9 +417,12 @@ sync_auth() {
     return
   fi
 
-  AGENTS=(taizi zhongshu menxia shangshu hubu libu bingbu xingbu gongbu libu_hr zaochao)
   SYNCED=0
-  for agent in "${AGENTS[@]}"; do
+  SYNC_TARGETS=("${AGENTS[@]}")
+  if [ "$INSTALL_MODE" = "sandbox" ]; then
+    SYNC_TARGETS=(taizi)
+  fi
+  for agent in "${SYNC_TARGETS[@]}"; do
     AGENT_DIR="$OC_HOME/agents/$agent/agent"
     if [ -d "$AGENT_DIR" ] || mkdir -p "$AGENT_DIR" 2>/dev/null; then
       cp "$MAIN_AUTH" "$AGENT_DIR/$AUTH_FILENAME"

--- a/scripts/sync_agent_config.py
+++ b/scripts/sync_agent_config.py
@@ -13,6 +13,7 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(name)s] %(message
 BASE = pathlib.Path(__file__).parent.parent
 DATA = BASE / 'data'
 OPENCLAW_CFG = pathlib.Path.home() / '.openclaw' / 'openclaw.json'
+SANDBOX_ROOT = pathlib.Path.home() / '.openclaw' / 'workspaces' / 'edict'
 
 ID_LABEL = {
     'taizi':    {'label': '太子',   'role': '太子',     'duty': '飞书消息分拣与回奏',  'emoji': '🤴'},
@@ -117,6 +118,27 @@ def _collect_openclaw_models(cfg):
     return KNOWN_MODELS + extra
 
 
+def _default_workspace_for(agent_id: str) -> str:
+    sandbox_ws = SANDBOX_ROOT / 'agents' / agent_id
+    if sandbox_ws.exists():
+        return str(sandbox_ws)
+    return str(pathlib.Path.home() / f'.openclaw/workspace-{agent_id}')
+
+
+def _discover_sandbox_agents():
+    discovered = {}
+    agents_dir = SANDBOX_ROOT / 'agents'
+    if not agents_dir.is_dir():
+        return discovered
+    for agent_dir in sorted(agents_dir.iterdir()):
+        if not agent_dir.is_dir():
+            continue
+        ag_id = agent_dir.name
+        if ag_id in ID_LABEL:
+            discovered[ag_id] = str(agent_dir)
+    return discovered
+
+
 def main():
     cfg = {}
     try:
@@ -129,6 +151,7 @@ def main():
     default_model = normalize_model(agents_cfg.get('defaults', {}).get('model', {}), 'unknown')
     agents_list = agents_cfg.get('list', [])
     merged_models = _collect_openclaw_models(cfg)
+    sandbox_agents = _discover_sandbox_agents()
 
     result = []
     seen_ids = set()
@@ -137,7 +160,7 @@ def main():
         if ag_id not in ID_LABEL:
             continue
         meta = ID_LABEL[ag_id]
-        workspace = ag.get('workspace', str(pathlib.Path.home() / f'.openclaw/workspace-{ag_id}'))
+        workspace = ag.get('workspace', _default_workspace_for(ag_id))
         if 'allowAgents' in ag:
             allow_agents = ag.get('allowAgents', []) or []
         else:
@@ -155,13 +178,13 @@ def main():
 
     # 补充不在 openclaw.json agents list 中的 agent（兼容旧版 main）
     EXTRA_AGENTS = {
-        'taizi':   {'model': default_model, 'workspace': str(pathlib.Path.home() / '.openclaw/workspace-taizi'),
+        'taizi':   {'model': default_model, 'workspace': _default_workspace_for('taizi'),
                     'allowAgents': ['zhongshu']},
         'main':    {'model': default_model, 'workspace': str(pathlib.Path.home() / '.openclaw/workspace-main'),
                     'allowAgents': ['zhongshu','menxia','shangshu','hubu','libu','bingbu','xingbu','gongbu','libu_hr']},
-        'zaochao': {'model': default_model, 'workspace': str(pathlib.Path.home() / '.openclaw/workspace-zaochao'),
+        'zaochao': {'model': default_model, 'workspace': _default_workspace_for('zaochao'),
                     'allowAgents': []},
-        'libu_hr': {'model': default_model, 'workspace': str(pathlib.Path.home() / '.openclaw/workspace-libu_hr'),
+        'libu_hr': {'model': default_model, 'workspace': _default_workspace_for('libu_hr'),
                     'allowAgents': ['shangshu']},
     }
     for ag_id, extra in EXTRA_AGENTS.items():
@@ -177,6 +200,21 @@ def main():
             'skills': get_skills(extra['workspace']),
             'allowAgents': extra['allowAgents'],
             'isDefaultModel': True,
+        })
+
+    for ag_id, workspace in sandbox_agents.items():
+        if ag_id in seen_ids or ag_id not in ID_LABEL:
+            continue
+        meta = ID_LABEL[ag_id]
+        result.append({
+            'id': ag_id,
+            'label': meta['label'], 'role': meta['role'], 'duty': meta['duty'], 'emoji': meta['emoji'],
+            'model': default_model,
+            'defaultModel': default_model,
+            'workspace': workspace,
+            'skills': get_skills(workspace),
+            'allowAgents': [],
+            'isSandboxOnly': True,
         })
 
     # 保留已有的 dispatchChannel 配置 (Fix #139)

--- a/tests/test_sandbox_install_mode.py
+++ b/tests/test_sandbox_install_mode.py
@@ -1,0 +1,67 @@
+import json
+import importlib.util
+from pathlib import Path
+
+
+def _load_module(rel_path, name):
+    root = Path(__file__).resolve().parents[1]
+    script_path = root / rel_path
+    spec = importlib.util.spec_from_file_location(name, script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sync_agent_config_discovers_sandbox_only_agents(tmp_path, monkeypatch):
+    sync_agent_config = _load_module('scripts/sync_agent_config.py', 'sync_agent_config_sandbox')
+
+    home = tmp_path / 'home'
+    home.mkdir()
+    sandbox_root = home / '.openclaw' / 'workspaces' / 'edict'
+    (sandbox_root / 'agents' / 'zhongshu' / 'skills' / 'planner').mkdir(parents=True)
+    (sandbox_root / 'agents' / 'zhongshu' / 'skills' / 'planner' / 'SKILL.md').write_text(
+        '---\nname: planner\ndescription: sandbox planner\n---\n\nSandbox planner\n'
+    )
+
+    cfg = {
+        'agents': {
+            'defaults': {'model': 'openai/gpt-4o'},
+            'list': [
+                {'id': 'taizi', 'workspace': str(home / '.openclaw' / 'workspace-taizi')}
+            ]
+        }
+    }
+    cfg_path = tmp_path / 'openclaw.json'
+    cfg_path.write_text(json.dumps(cfg, ensure_ascii=False))
+
+    monkeypatch.setattr(sync_agent_config.pathlib.Path, 'home', staticmethod(lambda: home))
+    monkeypatch.setattr(sync_agent_config, 'OPENCLAW_CFG', cfg_path)
+    monkeypatch.setattr(sync_agent_config, 'DATA', tmp_path / 'data')
+    monkeypatch.setattr(sync_agent_config, 'SANDBOX_ROOT', sandbox_root)
+
+    sync_agent_config.main()
+
+    out = json.loads((tmp_path / 'data' / 'agent_config.json').read_text())
+    zhongshu = next(agent for agent in out['agents'] if agent['id'] == 'zhongshu')
+    assert zhongshu['workspace'] == str(sandbox_root / 'agents' / 'zhongshu')
+    assert zhongshu['isSandboxOnly'] is True
+    assert zhongshu['skills'][0]['name'] == 'planner'
+
+
+def test_server_iter_task_data_dirs_includes_sandbox(monkeypatch, tmp_path):
+    server = _load_module('dashboard/server.py', 'server_sandbox')
+
+    data_dir = tmp_path / 'repo-data'
+    data_dir.mkdir()
+    sandbox_data = tmp_path / '.openclaw' / 'workspaces' / 'edict' / 'data'
+    sandbox_data.mkdir(parents=True)
+    global_ws_data = tmp_path / '.openclaw' / 'workspace-taizi' / 'data'
+    global_ws_data.mkdir(parents=True)
+
+    monkeypatch.setattr(server, 'DATA', data_dir)
+    monkeypatch.setattr(server, 'OCLAW_HOME', tmp_path / '.openclaw')
+
+    dirs = server._iter_task_data_dirs()
+    assert data_dir in dirs
+    assert sandbox_data in dirs
+    assert global_ws_data in dirs


### PR DESCRIPTION
## Summary\n- add a sandbox install mode to keep only taizi globally registered while placing the other agents under ~/.openclaw/workspaces/edict\n- let dashboard/config sync discover sandbox data and sandbox-only agents so unregistered departments still appear in the UI\n- document full vs sandbox installation flows and add targeted sandbox discovery tests\n\n## Verification\n- \n- \n- direct Python smoke test for  sandbox agent discovery\n\n## Notes\n- default/full install behavior is preserved\n- sandbox mode registers only  in openclaw.json; other agents live under the edict sandbox workspace\n