### PR TITLE
fix: unify local-time rendering in task modal

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -1956,13 +1956,24 @@ def get_task_activity(task_id):
         except Exception:
             pass
 
+    last_active = None
+    if updated_at:
+        try:
+            dt = _parse_iso(updated_at)
+            if dt:
+                last_active = dt.astimezone().strftime('%Y-%m-%d %H:%M:%S')
+            else:
+                last_active = updated_at[:19].replace('T', ' ')
+        except Exception:
+            last_active = updated_at[:19].replace('T', ' ')
+
     result = {
         'ok': True,
         'taskId': task_id,
         'taskMeta': task_meta,
         'agentId': agent_id,
         'agentLabel': _STATE_LABELS.get(state, state),
-        'lastActive': updated_at[:19].replace('T', ' ') if updated_at else None,
+        'lastActive': last_active,
         'activity': activity,
         'activitySource': 'progress+session',
         'relatedAgents': sorted(list(related_agents)),

--- a/edict/frontend/src/components/SessionsPanel.tsx
+++ b/edict/frontend/src/components/SessionsPanel.tsx
@@ -2,6 +2,22 @@ import { useStore, isEdict, STATE_LABEL, timeAgo } from '../store';
 import type { Task } from '../api';
 import { useState } from 'react';
 
+function fmtActivityTime(ts: string | number | undefined): string {
+  if (ts == null) return '';
+  if (typeof ts === 'number') {
+    const d = new Date(ts > 1e12 ? ts : ts * 1000);
+    if (isNaN(d.getTime())) return '';
+    return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
+  }
+  const s = String(ts).trim();
+  const m = s.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})$/);
+  const d = m
+    ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), Number(m[4]), Number(m[5]), Number(m[6]))
+    : new Date(s.includes(' ') ? s.replace(' ', 'T') : s);
+  if (isNaN(d.getTime())) return s.length >= 8 ? s.substring(0, 8) : s;
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
+}
+
 // Agent maps built from agentConfig
 function useAgentMaps() {
   const cfg = useStore((s) => s.agentConfig);
@@ -231,7 +247,7 @@ function SessionDetailModal({
                 const kLabel = kind === 'assistant' ? '回复' : kind === 'tool' ? '工具' : kind === 'user' ? '用户' : '事件';
                 let txt = (a.text || '').replace(/\[\[.*?\]\]/g, '').replace(/\*\*/g, '').trim();
                 if (txt.length > 200) txt = txt.substring(0, 200) + '…';
-                const time = ((a.at as string) || '').substring(11, 19);
+                const time = fmtActivityTime(a.at as string | number | undefined);
                 return (
                   <div key={i} style={{ padding: '8px 12px', borderBottom: '1px solid var(--line)', fontSize: 12, lineHeight: 1.5 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 3 }}>

--- a/edict/frontend/src/components/TaskModal.tsx
+++ b/edict/frontend/src/components/TaskModal.tsx
@@ -42,14 +42,41 @@ function fmtStalled(sec: number): string {
   return `${h}小时${m}分`;
 }
 
-function fmtActivityTime(ts: number | string | undefined): string {
-  if (!ts) return '';
+function parseDateFlexible(ts: number | string | undefined): Date | null {
+  if (ts == null || ts === '') return null;
   if (typeof ts === 'number') {
-    const d = new Date(ts);
-    return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
+    const d = new Date(ts > 1e12 ? ts : ts * 1000);
+    return isNaN(d.getTime()) ? null : d;
   }
-  if (typeof ts === 'string' && ts.length >= 19) return ts.substring(11, 19);
-  return String(ts).substring(0, 8);
+  const s = String(ts).trim();
+  if (!s) return null;
+  const localMatch = s.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})$/);
+  if (localMatch) {
+    const [, y, m, d, h, mi, se] = localMatch;
+    const dt = new Date(Number(y), Number(m) - 1, Number(d), Number(h), Number(mi), Number(se));
+    return isNaN(dt.getTime()) ? null : dt;
+  }
+  const iso = s.includes(' ') ? s.replace(' ', 'T') : s;
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function fmtDateTime(ts: number | string | undefined): string {
+  const d = parseDateFlexible(ts);
+  if (!d) return '';
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  const h = String(d.getHours()).padStart(2, '0');
+  const mi = String(d.getMinutes()).padStart(2, '0');
+  const se = String(d.getSeconds()).padStart(2, '0');
+  return `${y}-${m}-${day} ${h}:${mi}:${se}`;
+}
+
+function fmtActivityTime(ts: number | string | undefined): string {
+  const d = parseDateFlexible(ts);
+  if (!d) return '';
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
 }
 
 export default function TaskModal() {
@@ -302,8 +329,8 @@ export default function TaskModal() {
             </div>
             {sched && (
               <div className="sched-line">
-                {sched.lastProgressAt && <span>最近进展 {(sched.lastProgressAt || '').replace('T', ' ').substring(0, 19)}</span>}
-                {sched.lastDispatchAt && <span>最近派发 {(sched.lastDispatchAt || '').replace('T', ' ').substring(0, 19)}</span>}
+                {sched.lastProgressAt && <span>最近进展 {fmtDateTime(sched.lastProgressAt)}</span>}
+                {sched.lastDispatchAt && <span>最近派发 {fmtDateTime(sched.lastDispatchAt)}</span>}
                 <span>自动回滚 {sched.autoRollback === false ? '关闭' : '开启'}</span>
                 {sched.lastDispatchAgent && <span>目标 {sched.lastDispatchAgent}</span>}
               </div>
@@ -365,7 +392,7 @@ export default function TaskModal() {
                   const col = deptColor(fl.from || '');
                   return (
                     <div className="fl-item" key={i}>
-                      <div className="fl-time">{fl.at ? fl.at.substring(11, 16) : ''}</div>
+                      <div className="fl-time">{fmtActivityTime(fl.at).substring(0, 5)}</div>
                       <div className="fl-dot" style={{ background: col }} />
                       <div className="fl-content">
                         <div className="fl-who">
@@ -458,7 +485,7 @@ function LiveActivitySection({
   const agentParts: string[] = [];
   if (data.agentLabel) agentParts.push(data.agentLabel);
   if (data.relatedAgents && data.relatedAgents.length > 1) agentParts.push(`${data.relatedAgents.length}个 Agent`);
-  if (data.lastActive) agentParts.push(`最后活跃: ${data.lastActive}`);
+  if (data.lastActive) agentParts.push(`最后活跃: ${fmtDateTime(data.lastActive)}`);
 
   // Phase durations
   const phaseDurations = data.phaseDurations || [];


### PR DESCRIPTION
## 背景 / 问题
看板中存在多处时间显示与本地时区不一致的问题（Asia/Shanghai），表现为同一任务在不同区域显示时间前后不一致，影响排障和状态判断。

## 变更内容
本 PR 聚焦“时间显示一致性修复”，仅包含相关改动：

- 统一任务详情相关时间字段的解析与展示逻辑，按本地时区显示
- 修复会话面板活动时间显示，避免直接字符串截断导致的时区偏差
- 调整后端返回的活动时间格式化逻辑，确保前后端展示语义一致

涉及文件：
- `dashboard/server.py`
- `edict/frontend/src/components/TaskModal.tsx`
- `edict/frontend/src/components/SessionsPanel.tsx`

## 验证
已在本地完成验证：

1. 启动 dashboard 服务后访问看板页面
2. 对比任务卡片、任务详情、流转日志、最近活动等区域时间
3. 确认显示与本地系统时间（Asia/Shanghai）一致，且区域间一致

## 影响范围
- 仅影响时间展示与格式化逻辑
- 不改变任务流转业务状态机与派发逻辑

## 风险与回滚
- 风险较低，主要为展示层时间格式处理
- 如需回滚，可仅回退本 PR 涉及的上述 3 个文件
