### PR TITLE
fix(flow): prevent premature task completion before review

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -687,6 +687,13 @@ def handle_create_task(title, org='中书省', official='中书令', priority='n
     return {'ok': True, 'taskId': task_id, 'message': f'旨意 {task_id} 已下达，正在派发给太子'}
 
 
+def _todo_progress(task):
+    todos = task.get('todos') or []
+    total = len(todos)
+    completed = sum(1 for td in todos if td.get('status') == 'completed')
+    return completed, total
+
+
 def handle_review_action(task_id, action, comment=''):
     """门下省御批：准奏/封驳。"""
     tasks = load_tasks()
@@ -706,6 +713,9 @@ def handle_review_action(task_id, action, comment=''):
             remark = f'✅ 准奏：{comment or "门下省审议通过"}'
             to_dept = '尚书省'
         else:  # Review
+            completed, total = _todo_progress(task)
+            if total > 0 and completed < total:
+                return {'ok': False, 'error': f'子任务尚未全部完成（{completed}/{total}），不能直接准奏完结'}
             task['state'] = 'Done'
             task['now'] = '御批通过，任务完成'
             remark = f'✅ 御批准奏：{comment or "审查通过"}'

--- a/scripts/file_lock.py
+++ b/scripts/file_lock.py
@@ -103,7 +103,7 @@ def atomic_json_update(
             dir=str(path.parent), suffix='.tmp', prefix=path.stem + '_'
         )
         try:
-            with os.fdopen(tmp_fd, 'w') as f:
+            with os.fdopen(tmp_fd, 'w', encoding='utf-8') as f:
                 json.dump(result, f, ensure_ascii=False, indent=2)
             os.replace(tmp_path, str(path))
         except Exception:

--- a/scripts/kanban_update.py
+++ b/scripts/kanban_update.py
@@ -231,6 +231,14 @@ def _sanitize_remark(raw):
     return _sanitize_text(raw, 120)
 
 
+def _todo_counts(task):
+    """返回 (completed, total) 便于完成态校验。"""
+    todos = task.get('todos') or []
+    total = len(todos)
+    completed = sum(1 for td in todos if td.get('status') == 'completed')
+    return completed, total
+
+
 def _infer_agent_id_from_runtime(task=None):
     """尽量推断当前执行该命令的 Agent。"""
     for k in ('OPENCLAW_AGENT_ID', 'OPENCLAW_AGENT', 'AGENT_ID'):
@@ -429,18 +437,33 @@ def cmd_flow(task_id, from_dept, to_dept, remark):
 
 
 def cmd_done(task_id, output_path='', summary=''):
-    """标记任务完成（原子操作）"""
+    """执行部门回报完成，任务进入 Review 待尚书省汇总审查。"""
+    rejected = [False]
+    reject_reason = ['']
     def modifier(tasks):
         t = find_task(tasks, task_id)
         if not t:
             log.error(f'任务 {task_id} 不存在')
             return tasks
-        t['state'] = 'Done'
+        old_state = t.get('state')
+        if old_state not in ('Doing', 'Next'):
+            rejected[0] = True
+            reject_reason[0] = f'当前状态 {old_state} 不允许直接上报完成'
+            return tasks
+        completed, total = _todo_counts(t)
+        if total > 0 and completed < total:
+            rejected[0] = True
+            reject_reason[0] = f'todos 未完成（{completed}/{total}），禁止直接收口'
+            return tasks
+
+        from_org = t.get('org', '执行部门')
+        t['state'] = 'Review'
+        t['org'] = STATE_ORG_MAP.get('Review', t.get('org', ''))
         t['output'] = output_path
-        t['now'] = summary or '任务已完成'
+        t['now'] = summary or '执行已完成，提交尚书省汇总审查'
         t.setdefault('flow_log', []).append({
-            "at": now_iso(), "from": t.get('org', '执行部门'),
-            "to": "皇上", "remark": f"✅ 完成：{summary or '任务已完成'}"
+            "at": now_iso(), "from": from_org,
+            "to": "尚书省", "remark": f"✅ 执行完成，提交审查：{summary or '待尚书省汇总'}"
         })
         # 同步设置 outputMeta，避免依赖 refresh_live_data.py 异步补充
         if output_path:
@@ -454,8 +477,12 @@ def cmd_done(task_id, output_path='', summary=''):
         return tasks
     atomic_json_update(TASKS_FILE, modifier, [])
     _trigger_refresh()
-    log.info(f'✅ {task_id} 已完成')
-    _append_audit(task_id, _infer_agent_id_from_runtime(), 'done', None, output_path, summary)
+    if rejected[0]:
+        log.warning(f'⚠️ {task_id} done 被拒绝：{reject_reason[0]}')
+        _append_audit(task_id, _infer_agent_id_from_runtime(), 'done_rejected', None, 'Review', reject_reason[0])
+        return
+    log.info(f'✅ {task_id} 执行完成，已提交尚书省审查')
+    _append_audit(task_id, _infer_agent_id_from_runtime(), 'done', None, 'Review', summary or '')
 
 
 def cmd_block(task_id, reason):

--- a/tests/test_dashboard_review_action.py
+++ b/tests/test_dashboard_review_action.py
@@ -1,0 +1,78 @@
+"""Regression tests for dashboard review completion gates."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+
+
+DASHBOARD_DIR = pathlib.Path(__file__).resolve().parent.parent / "dashboard"
+sys.path.insert(0, str(DASHBOARD_DIR))
+
+_SPEC = importlib.util.spec_from_file_location("dashboard_server", DASHBOARD_DIR / "server.py")
+dashboard_server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(dashboard_server)
+
+
+def test_review_approve_rejects_incomplete_todos(monkeypatch):
+    """Review approve should not close a task when todos are still incomplete."""
+    tasks = [{
+        "id": "JJC-REVIEW-001",
+        "title": "review gate",
+        "state": "Review",
+        "org": "尚书省",
+        "now": "汇总中",
+        "flow_log": [],
+        "todos": [
+            {"id": "1", "title": "已完成", "status": "completed"},
+            {"id": "2", "title": "未完成", "status": "in-progress"},
+        ],
+    }]
+
+    saved = {}
+
+    monkeypatch.setattr(dashboard_server, "load_tasks", lambda: json.loads(json.dumps(tasks, ensure_ascii=False)))
+    monkeypatch.setattr(
+        dashboard_server,
+        "save_tasks",
+        lambda payload: saved.setdefault("tasks", json.loads(json.dumps(payload, ensure_ascii=False))),
+    )
+
+    result = dashboard_server.handle_review_action("JJC-REVIEW-001", "approve", "试图提前完结")
+
+    assert result["ok"] is False
+    assert "2/2" not in result["error"]
+    assert "不能直接准奏完结" in result["error"]
+    assert "tasks" not in saved
+
+
+def test_review_approve_allows_complete_todos(monkeypatch):
+    """Review approve may finish a task once all todos are completed."""
+    tasks = [{
+        "id": "JJC-REVIEW-002",
+        "title": "review gate ok",
+        "state": "Review",
+        "org": "尚书省",
+        "now": "汇总中",
+        "flow_log": [],
+        "todos": [
+            {"id": "1", "title": "已完成", "status": "completed"},
+            {"id": "2", "title": "已完成2", "status": "completed"},
+        ],
+    }]
+
+    saved = {}
+
+    monkeypatch.setattr(dashboard_server, "load_tasks", lambda: json.loads(json.dumps(tasks, ensure_ascii=False)))
+    monkeypatch.setattr(
+        dashboard_server,
+        "save_tasks",
+        lambda payload: saved.setdefault("tasks", json.loads(json.dumps(payload, ensure_ascii=False))),
+    )
+
+    result = dashboard_server.handle_review_action("JJC-REVIEW-002", "approve", "全部完成")
+
+    assert result["ok"] is True
+    assert saved["tasks"][0]["state"] == "Done"

--- a/tests/test_kanban.py
+++ b/tests/test_kanban.py
@@ -1,8 +1,10 @@
 """tests for scripts/kanban_update.py"""
-import json, pathlib, sys
+import json
+import pathlib
+import sys
 
 # Ensure scripts/ is importable
-SCRIPTS = pathlib.Path(__file__).resolve().parent.parent / 'scripts'
+SCRIPTS = pathlib.Path(__file__).resolve().parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import kanban_update as kb
@@ -10,161 +12,198 @@ import kanban_update as kb
 
 def test_create_and_get(tmp_path):
     """kanban create + get round-trip."""
-    tasks_file = tmp_path / 'tasks_source.json'
-    tasks_file.write_text('[]')
+    tasks_file = tmp_path / "tasks_source.json"
+    tasks_file.write_text("[]", encoding="utf-8")
 
-    # Patch TASKS_FILE
     original = kb.TASKS_FILE
     kb.TASKS_FILE = tasks_file
     try:
-        kb.cmd_create('TEST-001', '测试任务创建和查询功能验证', 'Inbox', '工部', '工部尚书')
-        tasks = json.loads(tasks_file.read_text())
-        assert any(t.get('id') == 'TEST-001' for t in tasks)
-        t = next(t for t in tasks if t['id'] == 'TEST-001')
-        assert t['title'] == '测试任务创建和查询功能验证'
-        assert t['state'] == 'Inbox'
-        assert t['org'] == '工部'
+        kb.cmd_create("TEST-001", "测试任务创建和查询功能验证", "Inbox", "工部", "工部尚书")
+        tasks = json.loads(tasks_file.read_text(encoding="utf-8"))
+        assert any(t.get("id") == "TEST-001" for t in tasks)
+        task = next(t for t in tasks if t["id"] == "TEST-001")
+        assert task["title"] == "测试任务创建和查询功能验证"
+        assert task["state"] == "Inbox"
+        assert task["org"] == "工部"
     finally:
         kb.TASKS_FILE = original
 
 
 def test_move_state(tmp_path):
     """kanban move changes task state."""
-    tasks_file = tmp_path / 'tasks_source.json'
+    tasks_file = tmp_path / "tasks_source.json"
     tasks_file.write_text(json.dumps([
-        {'id': 'T-1', 'title': 'test', 'state': 'Inbox'}
-    ]))
+        {"id": "T-1", "title": "test", "state": "Inbox"}
+    ], ensure_ascii=False), encoding="utf-8")
 
     original = kb.TASKS_FILE
     kb.TASKS_FILE = tasks_file
     try:
-        kb.cmd_state('T-1', 'Doing')
-        tasks = json.loads(tasks_file.read_text())
-        assert tasks[0]['state'] == 'Doing'
+        kb.cmd_state("T-1", "Doing")
+        tasks = json.loads(tasks_file.read_text(encoding="utf-8"))
+        assert tasks[0]["state"] == "Doing"
     finally:
         kb.TASKS_FILE = original
 
 
 def test_block_and_unblock(tmp_path):
-    """kanban block/unblock round-trip."""
-    tasks_file = tmp_path / 'tasks_source.json'
+    """kanban block round-trip."""
+    tasks_file = tmp_path / "tasks_source.json"
     tasks_file.write_text(json.dumps([
-        {'id': 'T-2', 'title': 'blocker test', 'state': 'Doing'}
-    ]))
+        {"id": "T-2", "title": "blocker test", "state": "Doing"}
+    ], ensure_ascii=False), encoding="utf-8")
 
     original = kb.TASKS_FILE
     kb.TASKS_FILE = tasks_file
     try:
-        kb.cmd_block('T-2', '等待依赖')
-        tasks = json.loads(tasks_file.read_text())
-        assert tasks[0]['state'] == 'Blocked'
-        assert tasks[0]['block'] == '等待依赖'
+        kb.cmd_block("T-2", "等待依赖")
+        tasks = json.loads(tasks_file.read_text(encoding="utf-8"))
+        assert tasks[0]["state"] == "Blocked"
+        assert tasks[0]["block"] == "等待依赖"
     finally:
         kb.TASKS_FILE = original
 
 
 def test_flow_log(tmp_path):
     """cmd_flow appends a flow_log entry."""
-    tasks_file = tmp_path / 'tasks_source.json'
+    tasks_file = tmp_path / "tasks_source.json"
     tasks_file.write_text(json.dumps([
-        {'id': 'T-3', 'title': 'flow test', 'state': 'Zhongshu', 'flow_log': []}
-    ]))
+        {"id": "T-3", "title": "flow test", "state": "Zhongshu", "flow_log": []}
+    ], ensure_ascii=False), encoding="utf-8")
 
     original = kb.TASKS_FILE
     kb.TASKS_FILE = tasks_file
     try:
-        kb.cmd_flow('T-3', '中书省', '门下省', '规划方案提交审核')
-        tasks = json.loads(tasks_file.read_text())
-        t = tasks[0]
-        assert len(t['flow_log']) == 1
-        assert t['flow_log'][0]['from'] == '中书省'
-        assert t['flow_log'][0]['to'] == '门下省'
+        kb.cmd_flow("T-3", "中书省", "门下省", "规划方案提交审议")
+        tasks = json.loads(tasks_file.read_text(encoding="utf-8"))
+        task = tasks[0]
+        assert len(task["flow_log"]) == 1
+        assert task["flow_log"][0]["from"] == "中书省"
+        assert task["flow_log"][0]["to"] == "门下省"
     finally:
         kb.TASKS_FILE = original
 
 
-def test_done(tmp_path):
-    """cmd_done marks task as Done with output and flow_log entry."""
-    tasks_file = tmp_path / 'tasks_source.json'
+def test_done_routes_to_review(tmp_path):
+    """cmd_done should route execution output back to Review instead of direct Done."""
+    tasks_file = tmp_path / "tasks_source.json"
     tasks_file.write_text(json.dumps([
-        {'id': 'T-4', 'title': 'done test', 'state': 'Doing', 'org': '兵部', 'flow_log': []}
-    ]))
+        {
+            "id": "T-4",
+            "title": "done test",
+            "state": "Doing",
+            "org": "兵部",
+            "flow_log": [],
+            "todos": [{"id": "1", "title": "收尾", "status": "completed"}],
+        }
+    ], ensure_ascii=False), encoding="utf-8")
 
     original = kb.TASKS_FILE
     kb.TASKS_FILE = tasks_file
     try:
-        kb.cmd_done('T-4', '/tmp/output.md', '功能已全部实现')
-        tasks = json.loads(tasks_file.read_text())
-        t = tasks[0]
-        assert t['state'] == 'Done'
-        assert t['output'] == '/tmp/output.md'
-        assert t['now'] == '功能已全部实现'
-        assert any('✅ 完成' in e.get('remark', '') for e in t['flow_log'])
+        kb.cmd_done("T-4", "/tmp/output.md", "功能已全部实现")
+        tasks = json.loads(tasks_file.read_text(encoding="utf-8"))
+        task = tasks[0]
+        assert task["state"] == "Review"
+        assert task["org"] == "尚书省"
+        assert task["output"] == "/tmp/output.md"
+        assert task["now"] == "功能已全部实现"
+        assert any("提交审查" in entry.get("remark", "") for entry in task["flow_log"])
+    finally:
+        kb.TASKS_FILE = original
+
+
+def test_done_rejects_incomplete_todos(tmp_path):
+    """cmd_done should be rejected when todos are still incomplete."""
+    tasks_file = tmp_path / "tasks_source.json"
+    tasks_file.write_text(json.dumps([
+        {
+            "id": "T-4B",
+            "title": "done gate test",
+            "state": "Doing",
+            "org": "工部",
+            "flow_log": [],
+            "todos": [
+                {"id": "1", "title": "已完成", "status": "completed"},
+                {"id": "2", "title": "未完成", "status": "in-progress"},
+            ],
+        }
+    ], ensure_ascii=False), encoding="utf-8")
+
+    original = kb.TASKS_FILE
+    kb.TASKS_FILE = tasks_file
+    try:
+        kb.cmd_done("T-4B", "/tmp/output.md", "试图提前收口")
+        tasks = json.loads(tasks_file.read_text(encoding="utf-8"))
+        task = tasks[0]
+        assert task["state"] == "Doing"
+        assert task.get("output", "") in ("", None)
+        assert task.get("flow_log", []) == []
     finally:
         kb.TASKS_FILE = original
 
 
 def test_progress(tmp_path):
     """cmd_progress updates now text and appends to progress_log."""
-    tasks_file = tmp_path / 'tasks_source.json'
+    tasks_file = tmp_path / "tasks_source.json"
     tasks_file.write_text(json.dumps([
-        {'id': 'T-5', 'title': 'progress test', 'state': 'Doing', 'org': '工部'}
-    ]))
+        {"id": "T-5", "title": "progress test", "state": "Doing", "org": "工部"}
+    ], ensure_ascii=False), encoding="utf-8")
 
     original = kb.TASKS_FILE
     kb.TASKS_FILE = tasks_file
     try:
-        kb.cmd_progress('T-5', '正在实现核心模块', '已完成需求分析✅|正在写代码🔄|待测试')
-        tasks = json.loads(tasks_file.read_text())
-        t = tasks[0]
-        assert t['now'] == '正在实现核心模块'
-        assert len(t.get('progress_log', [])) == 1
-        todos = t.get('todos', [])
+        kb.cmd_progress("T-5", "正在实现核心模块", "已完成需求分析✅|正在写代码🔄|待测试")
+        tasks = json.loads(tasks_file.read_text(encoding="utf-8"))
+        task = tasks[0]
+        assert task["now"] == "正在实现核心模块"
+        assert len(task.get("progress_log", [])) == 1
+        todos = task.get("todos", [])
         assert len(todos) == 3
-        statuses = {td['title']: td['status'] for td in todos}
-        assert statuses['已完成需求分析'] == 'completed'
-        assert statuses['正在写代码'] == 'in-progress'
-        assert statuses['待测试'] == 'not-started'
+        statuses = {td["title"]: td["status"] for td in todos}
+        assert statuses["已完成需求分析"] == "completed"
+        assert statuses["正在写代码"] == "in-progress"
+        assert statuses["待测试"] == "not-started"
     finally:
         kb.TASKS_FILE = original
 
 
 def test_todo(tmp_path):
     """cmd_todo adds and updates sub-tasks."""
-    tasks_file = tmp_path / 'tasks_source.json'
+    tasks_file = tmp_path / "tasks_source.json"
     tasks_file.write_text(json.dumps([
-        {'id': 'T-6', 'title': 'todo test', 'state': 'Doing'}
-    ]))
+        {"id": "T-6", "title": "todo test", "state": "Doing"}
+    ], ensure_ascii=False), encoding="utf-8")
 
     original = kb.TASKS_FILE
     kb.TASKS_FILE = tasks_file
     try:
-        kb.cmd_todo('T-6', '1', '实现登录接口', 'in-progress')
-        kb.cmd_todo('T-6', '2', '编写测试', 'not-started')
-        kb.cmd_todo('T-6', '1', '', 'completed')  # 更新第1条为完成
-        tasks = json.loads(tasks_file.read_text())
-        t = tasks[0]
-        todos = {td['id']: td for td in t.get('todos', [])}
-        assert todos['1']['status'] == 'completed'
-        assert todos['2']['status'] == 'not-started'
+        kb.cmd_todo("T-6", "1", "实现登录接口", "in-progress")
+        kb.cmd_todo("T-6", "2", "编写测试", "not-started")
+        kb.cmd_todo("T-6", "1", "", "completed")
+        tasks = json.loads(tasks_file.read_text(encoding="utf-8"))
+        task = tasks[0]
+        todos = {td["id"]: td for td in task.get("todos", [])}
+        assert todos["1"]["status"] == "completed"
+        assert todos["2"]["status"] == "not-started"
     finally:
         kb.TASKS_FILE = original
 
 
 def test_progress_log_capped(tmp_path):
     """progress_log should not exceed MAX_PROGRESS_LOG entries."""
-    tasks_file = tmp_path / 'tasks_source.json'
+    tasks_file = tmp_path / "tasks_source.json"
     tasks_file.write_text(json.dumps([
-        {'id': 'T-7', 'title': '日志上限测试', 'state': 'Doing', 'org': '礼部'}
-    ]))
+        {"id": "T-7", "title": "日志上限测试", "state": "Doing", "org": "礼部"}
+    ], ensure_ascii=False), encoding="utf-8")
 
     original = kb.TASKS_FILE
     kb.TASKS_FILE = tasks_file
     try:
         for i in range(kb.MAX_PROGRESS_LOG + 5):
-            kb.cmd_progress('T-7', f'第{i}次进展汇报内容，描述当前执行情况')
-        tasks = json.loads(tasks_file.read_text())
-        t = tasks[0]
-        assert len(t.get('progress_log', [])) == kb.MAX_PROGRESS_LOG
+            kb.cmd_progress("T-7", f"第{i}次进展汇报内容，描述当前执行情况")
+        tasks = json.loads(tasks_file.read_text(encoding="utf-8"))
+        task = tasks[0]
+        assert len(task.get("progress_log", [])) == kb.MAX_PROGRESS_LOG
     finally:
         kb.TASKS_FILE = original


### PR DESCRIPTION
﻿## Summary

**Issue:** #191 - 六部派发闭环不稳定：任务常卡在中书省/尚书省
**Type:** Bug Fix
**Severity:** High

This PR closes one confirmed root cause behind Issue #191: tasks could be marked complete even when their todos were still unfinished. It aligns execution completion with the existing review flow, adds completion gates in the dashboard approval path, and adds regression coverage for both paths.

---

## Root Cause

Two code paths could bypass the intended completion gate and write `Done` too early:

- `scripts/kanban_update.py:439`
  - `cmd_done()` wrote `state = 'Done'` directly from execution states without validating whether `todos` were fully completed.
- `dashboard/server.py:697`
  - `handle_review_action(..., 'approve')` allowed `Review -> Done` without checking todo completion, so the dashboard could also close tasks prematurely.
- `scripts/file_lock.py:106`
  - On Windows, `atomic_json_update()` wrote temp files without explicit UTF-8 encoding, which could raise `UnicodeEncodeError` during local reproduction when flow remarks contained emoji/Chinese text.

That left three inconsistent completion semantics in the codebase:

```python
# Before
cmd_state('Review', 'Done') -> guarded by PendingConfirm
cmd_done(...) -> direct Done
handle_review_action(..., 'approve') -> direct Done
```

```python
# After
cmd_state('Review', 'Done') -> existing guarded path unchanged
cmd_done(...) -> validate todos, then route back to Review
handle_review_action(..., 'approve') -> validate todos before Done
```

---

## Fix Description

**Changed files:**
- `scripts/kanban_update.py:234` - add `_todo_counts()` and reuse it in `cmd_done()`
- `scripts/kanban_update.py:439` - change `cmd_done()` from direct completion to `Review` handoff with todo gate and rejection audit
- `dashboard/server.py:690` - add `_todo_progress()` and block `Review -> Done` when todos are incomplete
- `scripts/file_lock.py:106` - force UTF-8 temp writes in atomic JSON updates on Windows
- `tests/test_kanban.py` - update expectations for `cmd_done()` and add incomplete-todo regression coverage
- `tests/test_dashboard_review_action.py` - add dashboard approval regression tests

Why this approach:
- It reuses the existing `Review` state instead of introducing a new completion path.
- It keeps the final `Done` transition in the review layer, which matches the current workflow semantics better than letting execution agents close tasks outright.
- It fixes a Windows-only write-path issue that was interfering with reliable reproduction and regression testing.

Known limitation:
- This PR closes the confirmed premature-completion bug, but Issue #191 may still include separate runtime dispatch/retry instability that needs further investigation in a full OpenClaw environment.

---

## Test Results

| Test | Description | Status |
|------|-------------|--------|
| `pytest tests/test_kanban.py tests/test_dashboard_review_action.py` | Covers `cmd_done()` handoff behavior and dashboard review completion gates | PASS |
| `python -m py_compile scripts/file_lock.py scripts/kanban_update.py dashboard/server.py tests/test_kanban.py tests/test_dashboard_review_action.py` | Syntax check for touched runtime and test files | PASS |

Manual reproduction before fix:
1. Create a `Doing` task with `todos` at `2/5` complete.
2. Run `cmd_done()`.
3. The task was written to `Done` directly.

Result after fix:
1. The same task is rejected from early completion and stays out of `Done`.
2. A task with all todos completed is routed back to `Review` for final approval.
3. Dashboard `approve` in `Review` now rejects incomplete todos instead of closing the task.

---

## Disprove Analysis

### Is this already fixed elsewhere?
- I checked Issue #191 on `2026-04-12`; it is still open.
- I also checked for upstream PRs referencing `191` and did not find an in-flight fix covering this path.
- `b7ad34a` and `4e51e34` improved dispatch/retry behavior, but they did not close this completion-gate gap.

### Default flow regression risk
- Tasks with fully completed todos can still progress to final completion.
- `cmd_done()` now returns work to `Review`, which preserves the existing review step instead of bypassing it.
- `cmd_state('Review', 'Done')` behavior is unchanged.

### Edge cases considered
- No todos present: `cmd_done()` still allows handoff to `Review`.
- Incomplete todos in `Review`: dashboard approval now rejects completion with an explicit error.
- Windows local runs: UTF-8 temp writes prevent encoding-related false negatives during JSON updates.

### Known limitation
- This PR does not claim to solve every symptom in #191. It specifically fixes the confirmed premature-completion paths and their regression coverage.

---

## Checklist

- [x] Code follows existing project style and keeps user-facing errors in Chinese where applicable
- [x] Related issue number is referenced in this PR (`#191`)
- [x] Tests were added/updated for the fixed paths
- [x] No hardcoded secrets, paths, or debug-only output introduced

Found during issue triage and local reproduction. Happy to adjust if you prefer a different completion gate shape.
