### PR TITLE
fix(ci): skip labeler for fork pull requests

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   label:
+    # Fork PRs do not get a write-capable GITHUB_TOKEN under pull_request,
+    # so actions/labeler would fail with "Resource not accessible by integration".
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v6


### PR DESCRIPTION
﻿## Summary

**Issue:** CI false-red on fork pull requests in `Auto Label PRs`
**Type:** Bug Fix
**Severity:** Low

This PR avoids a false-red CI failure in fork PRs by skipping the `label` job when the pull request head repo is a fork. The existing `size-label` job remains unchanged.

---

## Root Cause

`actions/labeler@v6` needs write permission to add labels to pull requests, but fork PRs triggered via `pull_request` do not get a write-capable `GITHUB_TOKEN` in this context.

Current workflow:
- `.github/workflows/auto-label.yml:12`
- `label` always runs on `pull_request`
- for fork PRs, the action fails with `Resource not accessible by integration`

That means fork-based contribution PRs can go red even when no functional checks are failing.

---

## Fix Description

**Changed files:**
- `.github/workflows/auto-label.yml:12` - skip the `label` job when `github.event.pull_request.head.repo.fork` is true

Why this approach:
- It is the smaller and safer change.
- It preserves current behavior for same-repo PRs.
- It keeps `size-label` unchanged, so PR sizing still works.

If you would prefer to preserve auto-labeling for fork PRs as well, I’m happy to switch this to a `pull_request_target`-based approach or another workflow shape you prefer.

---

## Test Results

| Test | Description | Status |
|------|-------------|--------|
| Diff inspection | Verified only the `label` job condition changed | PASS |
| Existing workflow behavior review | Confirmed `size-label` remains untouched | PASS |

> I did not run `actionlint` locally in this environment.

---

## Disprove Analysis

### Is this already fixed elsewhere?
- I checked the current workflow configuration in `main`; the `label` job still runs unconditionally on `pull_request`.
- The recent failure on `cft0808/edict#280` reproduces the problem path directly.

### Impact scope
- Same-repo PRs still run the `label` job as before.
- Fork PRs skip only the failing label step.
- `size-label` still runs for both cases.

### Edge cases
- This does not change repo labeling rules or label matching config.
- This only avoids the permission failure path for fork PRs.

### Known limitation
- Fork PRs will not receive `actions/labeler` labels under this conservative fix.
- If maintaining those labels for forks is important, a different workflow shape would be more appropriate.

---

## Checklist

- [x] Change is scoped to a single workflow file
- [x] No functional runtime code changed
- [x] Existing same-repo behavior remains intact
- [x] Leaves room for a different maintainer-preferred workflow approach

Found while investigating the failing `label` check on a fork PR. Happy to adjust if you prefer a different workflow strategy.
