### PR TITLE
fix(dashboard): normalize task modal timestamps to local time

### DIFF
--- a/edict/frontend/src/components/TaskModal.tsx
+++ b/edict/frontend/src/components/TaskModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { useStore, getPipeStatus, deptColor, stateLabel, STATE_LABEL } from '../store';
 import { api } from '../api';
+import { formatDashboardDateTime, formatDashboardTime } from '../time';
 import type {
   Task,
   TaskActivityData,
@@ -43,13 +44,7 @@ function fmtStalled(sec: number): string {
 }
 
 function fmtActivityTime(ts: number | string | undefined): string {
-  if (!ts) return '';
-  if (typeof ts === 'number') {
-    const d = new Date(ts);
-    return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
-  }
-  if (typeof ts === 'string' && ts.length >= 19) return ts.substring(11, 19);
-  return String(ts).substring(0, 8);
+  return formatDashboardTime(ts, { showSeconds: true });
 }
 
 export default function TaskModal() {
@@ -302,8 +297,8 @@ export default function TaskModal() {
             </div>
             {sched && (
               <div className="sched-line">
-                {sched.lastProgressAt && <span>最近进展 {(sched.lastProgressAt || '').replace('T', ' ').substring(0, 19)}</span>}
-                {sched.lastDispatchAt && <span>最近派发 {(sched.lastDispatchAt || '').replace('T', ' ').substring(0, 19)}</span>}
+                {sched.lastProgressAt && <span>最近进展 {formatDashboardDateTime(sched.lastProgressAt)}</span>}
+                {sched.lastDispatchAt && <span>最近派发 {formatDashboardDateTime(sched.lastDispatchAt)}</span>}
                 <span>自动回滚 {sched.autoRollback === false ? '关闭' : '开启'}</span>
                 {sched.lastDispatchAgent && <span>目标 {sched.lastDispatchAgent}</span>}
               </div>
@@ -365,7 +360,7 @@ export default function TaskModal() {
                   const col = deptColor(fl.from || '');
                   return (
                     <div className="fl-item" key={i}>
-                      <div className="fl-time">{fl.at ? fl.at.substring(11, 16) : ''}</div>
+                      <div className="fl-time">{formatDashboardTime(fl.at, { showSeconds: false })}</div>
                       <div className="fl-dot" style={{ background: col }} />
                       <div className="fl-content">
                         <div className="fl-who">
@@ -458,7 +453,7 @@ function LiveActivitySection({
   const agentParts: string[] = [];
   if (data.agentLabel) agentParts.push(data.agentLabel);
   if (data.relatedAgents && data.relatedAgents.length > 1) agentParts.push(`${data.relatedAgents.length}个 Agent`);
-  if (data.lastActive) agentParts.push(`最后活跃: ${data.lastActive}`);
+  if (data.lastActive) agentParts.push(`最后活跃: ${formatDashboardDateTime(data.lastActive)}`);
 
   // Phase durations
   const phaseDurations = data.phaseDurations || [];

--- a/edict/frontend/src/time.ts
+++ b/edict/frontend/src/time.ts
@@ -1,0 +1,57 @@
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+export function parseDashboardTimestamp(value: number | string | undefined | null): Date | null {
+  if (value === undefined || value === null || value === '') return null;
+
+  if (typeof value === 'number') {
+    const ms = Math.abs(value) < 1e12 ? value * 1000 : value;
+    const d = new Date(ms);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+
+  const raw = String(value).trim();
+  if (!raw) return null;
+
+  if (/^\d+(\.\d+)?$/.test(raw)) {
+    return parseDashboardTimestamp(Number(raw));
+  }
+
+  let normalized = raw;
+  if (normalized.includes(' ') && !normalized.includes('T')) {
+    normalized = normalized.replace(' ', 'T');
+  }
+
+  const looksIso = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(normalized);
+  const hasTimezone = /(?:Z|[+\-]\d{2}:\d{2})$/i.test(normalized);
+  if (looksIso && !hasTimezone) {
+    normalized += 'Z';
+  }
+
+  const d = new Date(normalized);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export function formatDashboardTime(
+  value: number | string | undefined | null,
+  { showSeconds = true }: { showSeconds?: boolean } = {}
+): string {
+  const d = parseDashboardTimestamp(value);
+  if (!d) return '';
+  const hh = pad2(d.getHours());
+  const mm = pad2(d.getMinutes());
+  if (!showSeconds) return `${hh}:${mm}`;
+  return `${hh}:${mm}:${pad2(d.getSeconds())}`;
+}
+
+export function formatDashboardDateTime(
+  value: number | string | undefined | null,
+  { showSeconds = true }: { showSeconds?: boolean } = {}
+): string {
+  const d = parseDashboardTimestamp(value);
+  if (!d) return '';
+  const date = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+  const time = formatDashboardTime(d.getTime(), { showSeconds });
+  return `${date} ${time}`;
+}


### PR DESCRIPTION
﻿## Summary

**Issue:** #277 - 任务详情弹窗内多个时间字段存在时区口径不一致问题
**Type:** Bug Fix
**Severity:** Medium

This PR normalizes timestamp parsing inside the task detail modal so all relevant time fields are rendered in the browser's local timezone. It removes the current UTC/local mix across scheduler info, flow log entries, and live activity timestamps.

---

## Root Cause

The task detail modal was using multiple incompatible display paths for the same class of timestamp values:

- `edict/frontend/src/components/TaskModal.tsx:46`
  - `fmtActivityTime()` returned `ts.substring(11, 19)` for string timestamps, which displayed raw UTC clock text instead of local time.
- `edict/frontend/src/components/TaskModal.tsx:300`
  - scheduler timestamps (`lastProgressAt` / `lastDispatchAt`) were rendered via string slicing as well.
- `edict/frontend/src/components/TaskModal.tsx:363`
  - flow log timestamps were also truncated directly from the ISO string.
- `dashboard/server.py` already emits UTC ISO timestamps via `now_iso()`, so the data source was mostly consistent; the inconsistency came from the frontend display logic.

```ts
// Before
flow.at            -> substring(...)
scheduler.at       -> replace('T', ' ').substring(...)
activity.at        -> substring(...)
```

```ts
// After
flow.at            -> shared local-time formatter
scheduler.at       -> shared local datetime formatter
activity.at        -> shared local-time formatter
```

---

## Fix Description

**Changed files:**
- `edict/frontend/src/time.ts:1` - add a shared timestamp parser/formatter that normalizes UTC-ish strings and numeric timestamps into browser-local display values
- `edict/frontend/src/components/TaskModal.tsx:4` - import the shared formatter utilities
- `edict/frontend/src/components/TaskModal.tsx:46` - route activity timestamps through the shared local formatter
- `edict/frontend/src/components/TaskModal.tsx:300` - render scheduler timestamps with unified local datetime formatting
- `edict/frontend/src/components/TaskModal.tsx:363` - render flow log timestamps with the same local parsing logic
- `edict/frontend/src/components/TaskModal.tsx:456` - align the “最后活跃” summary line with the same formatter

Why this approach:
- It keeps the fix scoped to the actual bug surface: the task detail modal.
- It avoids changing backend timestamp storage or API semantics.
- It preserves each section's existing display granularity (`YYYY-MM-DD HH:mm:ss`, `HH:mm`, `HH:mm:ss`) while unifying timezone handling.

---

## Test Results

| Test | Description | Status |
|------|-------------|--------|
| `npm.cmd install` | Install missing local frontend dependencies so TypeScript/Vite build can run in this workspace | PASS |
| `npm.cmd run build` | Type-check and production-build the frontend after the timestamp formatting change | PASS |

Manual verification target:
1. Open a task detail modal.
2. Compare `最近进展` / `最近派发`, flow log timestamps, `最近更新`, and activity item timestamps.
3. Confirm they all now render in the same local timezone basis.

---

## Disprove Analysis

### Is this already fixed elsewhere?
- Issue #277 is still open as of 2026-04-12.
- I did not find an upstream PR referencing #277.
- `upstream/main` still contains the string-slicing display paths in `TaskModal.tsx`.

### Impact scope
- The change is limited to the React task detail modal.
- Backend APIs and timestamp generation remain unchanged.
- Display precision stays consistent with the existing UI intent.

### Edge cases
- Numeric timestamps are normalized as seconds-or-milliseconds before formatting.
- ISO-like strings without explicit timezone suffix are treated as UTC for consistent rendering with current dashboard data.
- Invalid/empty timestamps still degrade to empty display strings instead of throwing.

### Known limitation
- This PR only fixes the React task modal path served from `dashboard/dist`.
- It does not attempt to refactor every other historical timestamp formatter in the repo.

---

## Checklist

- [x] 代码遵循现有项目风格
- [x] 相关 issue 编号已在 PR 描述中引用（`#277`）
- [x] 已提供构建验证与手动验证口径
- [x] 未引入硬编码路径、密钥或调试输出

Found during issue triage and reproduced through code-path inspection of the current dashboard modal. Happy to adjust if you prefer a different timestamp normalization policy.
