### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/scripts/skill_manager.py
+++ b/scripts/skill_manager.py
@@ -243,6 +243,7 @@ OFFICIAL_SKILLS_HUB = {
     'data_analysis': _get_hub_url('data_analysis'),
     'doc_generation': _get_hub_url('doc_generation'),
     'test_framework': _get_hub_url('test_framework'),
+    'mmx_cli': 'https://raw.githubusercontent.com/MiniMax-AI/cli/main/skill/SKILL.md',
 }
 
 SKILL_AGENT_MAPPING = {
@@ -252,6 +253,7 @@ SKILL_AGENT_MAPPING = {
     'data_analysis': ('hubu', 'menxia'),
     'doc_generation': ('libu', 'menxia'),
     'test_framework': ('gongbu', 'xingbu', 'menxia'),
+    'mmx_cli': ('menxia', 'shangshu'),
 }
 
 


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to `OFFICIAL_SKILLS_HUB` in `scripts/skill_manager.py` so the mmx-cli skill is discoverable out of the box
- Add `mmx_cli` to `SKILL_AGENT_MAPPING` targeting `menxia` and `shangshu` agents
- Users can install via `python3 scripts/skill_manager.py import-official-hub` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**2 lines changed, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- `python3 scripts/skill_manager.py import-official-hub` includes `mmx_cli` in the skill list
- `python3 scripts/skill_manager.py add-remote --agent menxia --name mmx_cli --source https://raw.githubusercontent.com/MiniMax-AI/cli/main/skill/SKILL.md` installs successfully
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal