### PR TITLE
fix(dashboard): handle missing OpenClaw CLI during dispatch

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -11,7 +11,7 @@ Endpoints:
   GET  /api/model-change-log   → data/model_change_log.json
   GET  /api/last-result        → data/last_model_change_result.json
 """
-import json, pathlib, subprocess, sys, threading, argparse, datetime, logging, re, os, socket
+import json, pathlib, subprocess, sys, threading, argparse, datetime, logging, re, os, socket, shutil
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
@@ -1045,6 +1045,18 @@ def _scheduler_mark_progress(task, note=''):
     sched['lastEscalatedAt'] = None
     if note:
         _scheduler_add_flow(task, f'进展确认：{note}')
+
+
+def _resolve_openclaw_bin():
+    """Return the OpenClaw CLI path used by dashboard dispatch.
+
+    On Windows, npm-installed CLIs are commonly exposed as .cmd shims.  Using
+    shutil.which lets Python resolve that shim before subprocess runs.
+    """
+    configured = os.environ.get('OPENCLAW_BIN', '').strip()
+    if configured:
+        return configured
+    return shutil.which('openclaw')
 
 
 def _update_task_scheduler(task_id, updater):
@@ -2083,7 +2095,22 @@ def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
             # "unknown channel: feishu" 错误（非飞书用户）
             _agent_cfg = read_json(DATA / 'agent_config.json', {})
             _channel = (_agent_cfg.get('dispatchChannel') or '').strip()
-            cmd = ['openclaw', 'agent', '--agent', agent_id, '-m', msg, '--timeout', '300']
+            openclaw_bin = _resolve_openclaw_bin()
+            if not openclaw_bin:
+                err = 'OpenClaw CLI 未找到：请确认已安装 openclaw 并加入 PATH；Windows 可设置 OPENCLAW_BIN 指向 openclaw.cmd'
+                log.warning(f'⚠️ {task_id} 自动派发异常: {err}')
+                _update_task_scheduler(task_id, lambda t, s: (
+                    s.update({
+                        'lastDispatchAt': now_iso(),
+                        'lastDispatchStatus': 'openclaw-missing',
+                        'lastDispatchAgent': agent_id,
+                        'lastDispatchTrigger': trigger,
+                        'lastDispatchError': err,
+                    }),
+                    _scheduler_add_flow(t, f'派发异常：OpenClaw CLI 未找到（{trigger}）', to=t.get('org', ''))
+                ))
+                return
+            cmd = [openclaw_bin, 'agent', '--agent', agent_id, '-m', msg, '--timeout', '300']
             if _channel:
                 cmd.extend(['--deliver', '--channel', _channel])
             max_retries = 2
@@ -2131,6 +2158,19 @@ def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
                     'lastDispatchError': 'timeout',
                 }),
                 _scheduler_add_flow(t, f'派发超时：{agent_id}（{trigger}）', to=t.get('org', ''))
+            ))
+        except FileNotFoundError as e:
+            err = f'OpenClaw CLI 未找到：{e}'
+            log.warning(f'⚠️ {task_id} 自动派发异常: {err}')
+            _update_task_scheduler(task_id, lambda t, s: (
+                s.update({
+                    'lastDispatchAt': now_iso(),
+                    'lastDispatchStatus': 'openclaw-missing',
+                    'lastDispatchAgent': agent_id,
+                    'lastDispatchTrigger': trigger,
+                    'lastDispatchError': err[:200],
+                }),
+                _scheduler_add_flow(t, f'派发异常：OpenClaw CLI 未找到（{trigger}）', to=t.get('org', ''))
             ))
         except Exception as e:
             log.warning(f'⚠️ {task_id} 自动派发异常: {e}')

--- a/tests/test_dashboard_dispatch.py
+++ b/tests/test_dashboard_dispatch.py
@@ -1,0 +1,59 @@
+"""Tests for dashboard auto-dispatch error handling."""
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / 'dashboard'))
+sys.path.insert(0, str(ROOT / 'scripts'))
+
+
+def test_dispatch_records_missing_openclaw_cli(monkeypatch, tmp_path):
+    """Missing OpenClaw CLI should become an actionable dispatch status."""
+    import server as srv
+
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    task_id = 'JJC-20260415-004'
+    task = {
+        'id': task_id,
+        'title': '小任务',
+        'state': 'Taizi',
+        'org': '太子',
+        'updatedAt': '2026-04-15T15:34:16Z',
+    }
+    tasks_path = data_dir / 'tasks_source.json'
+    tasks_path.write_text(json.dumps([task], ensure_ascii=False), encoding='utf-8')
+    (data_dir / 'agent_config.json').write_text('{}', encoding='utf-8')
+
+    monkeypatch.setattr(srv, 'DATA', data_dir)
+    monkeypatch.setattr(srv, '_ACTIVE_TASK_DATA_DIR', data_dir)
+    monkeypatch.setattr(srv, '_check_gateway_alive', lambda: True)
+    monkeypatch.setattr(srv, '_resolve_openclaw_bin', lambda: None)
+    monkeypatch.setattr(
+        srv,
+        'save_tasks',
+        lambda tasks: tasks_path.write_text(
+            json.dumps(tasks, ensure_ascii=False),
+            encoding='utf-8',
+        ),
+    )
+
+    class ImmediateThread:
+        def __init__(self, target=None, daemon=None):
+            self.target = target
+
+        def start(self):
+            if self.target:
+                self.target()
+
+    monkeypatch.setattr(srv.threading, 'Thread', ImmediateThread)
+
+    srv.dispatch_for_state(task_id, task, 'Taizi', trigger='test')
+
+    updated = json.loads(tasks_path.read_text(encoding='utf-8'))[0]
+    sched = updated['_scheduler']
+    assert sched['lastDispatchStatus'] == 'openclaw-missing'
+    assert 'OpenClaw CLI 未找到' in sched['lastDispatchError']
+    assert '[WinError 2]' not in sched['lastDispatchError']
+    assert any('OpenClaw CLI 未找到' in item['remark'] for item in updated['flow_log'])


### PR DESCRIPTION
﻿## Summary

**Issue:** #289 — 自动派发异常: `[WinError 2] 系统找不到指定的文件`
**Type:** Bug Fix
**Severity:** Medium

This PR makes dashboard auto-dispatch handle a missing OpenClaw CLI explicitly. Instead of surfacing a raw Windows `[WinError 2]` message to users, the scheduler now records an actionable `openclaw-missing` status and explains how to fix PATH / `OPENCLAW_BIN`.

---

## Root Cause

`dashboard/server.py::dispatch_for_state()` builds the auto-dispatch command with a hardcoded executable name:

```python
cmd = ['openclaw', 'agent', '--agent', agent_id, '-m', msg, '--timeout', '300']
result = subprocess.run(cmd, capture_output=True, text=True, timeout=310)
```

On Windows, if `openclaw` is not on PATH, or if the npm-installed CLI is exposed through an `openclaw.cmd` shim that is not resolved, `subprocess.run()` raises `FileNotFoundError` / `[WinError 2]`. The old dashboard path only caught the generic `Exception`, so the task scheduler displayed a non-actionable dispatch error.

This is different from OpenClaw runtime failures: the process never starts.

---

## Fix Description

**Changed files:**
- `dashboard/server.py` — add `_resolve_openclaw_bin()` using `OPENCLAW_BIN` or `shutil.which('openclaw')`
- `dashboard/server.py` — preflight the CLI before dispatching, recording `lastDispatchStatus = openclaw-missing` if it is unavailable
- `dashboard/server.py` — add a dedicated `FileNotFoundError` fallback for invalid configured paths
- `tests/test_dashboard_dispatch.py` — add a regression test for the missing CLI path

Rationale:
- `shutil.which()` resolves Windows npm `.cmd` shims more reliably than passing a bare command name directly
- `OPENCLAW_BIN` gives Windows users a direct escape hatch if their shell PATH differs from the dashboard process PATH
- The fix is scoped to dashboard auto-dispatch error handling and does not change the state machine or OpenClaw command arguments

---

## Test Results

| Test | Description | Status |
|------|-------------|--------|
| `pytest tests/test_dashboard_dispatch.py tests/test_server.py` | Covers missing OpenClaw CLI dispatch path plus existing server health route | ✅ PASS |
| `python -m py_compile dashboard/server.py tests/test_dashboard_dispatch.py` | Syntax check for changed Python files | ✅ PASS |
| `git diff --check` | Whitespace / patch formatting check | ✅ PASS |

---

## Disprove Analysis

### 是否已有其他地方修复
`edict/backend/app/workers/dispatch_worker.py` already catches `FileNotFoundError` and reports `openclaw command not found`, but the stdlib dashboard server still had its own legacy auto-dispatch path without the same protection. #289 maps to the dashboard scheduler message, so that path still needed a fix.

### 影响范围
This only affects dashboard auto-dispatch when the OpenClaw CLI cannot be resolved or launched. Successful dispatch still uses the same command shape:

```text
openclaw agent --agent <agent_id> -m <message> --timeout 300
```

### 边界情况
- If `openclaw` is available on PATH, dispatch proceeds as before.
- If Windows exposes `openclaw.cmd`, `shutil.which('openclaw')` can resolve it.
- If users need a custom path, they can set `OPENCLAW_BIN`.
- If `OPENCLAW_BIN` points to a bad path, `FileNotFoundError` is still converted to `openclaw-missing`.

### 已知局限
This does not install OpenClaw automatically. It only turns a raw `[WinError 2]` into an actionable dashboard error so users can fix their CLI/PATH setup.

---

## Checklist

- [x] 代码遵循项目现有风格
- [x] 相关 issue 编号在 PR 描述中已引用
- [x] 有测试覆盖
- [x] 无硬编码路径、密钥、调试输出

Found during issue triage. Happy to adjust the status wording if you prefer a different dashboard label.
