### PR TITLE
fix: require Python 3.10+ in edict startup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ venv/
 # Node.js
 node_modules/
 edict/frontend/node_modules/
+edict/frontend/dist/
 *.tsbuildinfo
 
 # Vite cache

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ docker compose up
 
 #### 前置条件
 - [OpenClaw](https://openclaw.ai) 已安装
-- Python 3.9+
+- Python 3.10+
 - macOS / Linux
 
 #### 安装

--- a/scripts/run_loop.sh
+++ b/scripts/run_loop.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export EDICT_HOME="${EDICT_HOME:-$(dirname "$SCRIPT_DIR")}"
+PYTHON_BIN="${EDICT_PYTHON:-python3}"
 INTERVAL="${1:-15}"
 LOG="/tmp/sansheng_liubu_refresh.log"
 PIDFILE="/tmp/sansheng_liubu_refresh.pid"
@@ -58,14 +59,14 @@ echo "   按 Ctrl+C 停止"
 safe_run() {
   local script="$1"
   if command -v timeout &>/dev/null; then
-    timeout "$SCRIPT_TIMEOUT" python3 "$script" >> "$LOG" 2>&1 || {
+    timeout "$SCRIPT_TIMEOUT" "$PYTHON_BIN" "$script" >> "$LOG" 2>&1 || {
       local rc=$?
       if [[ $rc -eq 124 ]]; then
         echo "$(date '+%H:%M:%S') [loop] ⚠️ 脚本超时(${SCRIPT_TIMEOUT}s): $script" >> "$LOG"
       fi
     }
   else
-    python3 "$script" >> "$LOG" 2>&1 || true
+    "$PYTHON_BIN" "$script" >> "$LOG" 2>&1 || true
   fi
 }
 

--- a/start.sh
+++ b/start.sh
@@ -9,11 +9,27 @@ cd "$REPO_DIR"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
 
-# 检查 Python
-if ! command -v python3 &>/dev/null; then
-  echo -e "${RED}❌ 未找到 python3，请先安装 Python 3.9+${NC}"
+resolve_python() {
+  local candidate version major minor
+  for candidate in "${EDICT_PYTHON:-}" python3.12 python3.11 python3.10 python3; do
+    [ -n "$candidate" ] || continue
+    command -v "$candidate" &>/dev/null || continue
+    version=$("$candidate" -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")' 2>/dev/null) || continue
+    major=${version%%.*}
+    minor=${version#*.}
+    if [ "$major" -gt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -ge 10 ]; }; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+PYTHON_BIN=$(resolve_python) || {
+  echo -e "${RED}❌ 未找到可用的 Python 3.10+（当前项目实际需要 3.10+）${NC}"
   exit 1
-fi
+}
+export EDICT_PYTHON="$PYTHON_BIN"
 
 # 确保 data 目录存在
 mkdir -p "$REPO_DIR/data"
@@ -57,7 +73,8 @@ fi
 
 # 启动看板服务器
 echo -e "${GREEN}▶ 启动看板服务器...${NC}"
-python3 dashboard/server.py &
+echo -e "${GREEN}   使用 Python: ${PYTHON_BIN} ($($PYTHON_BIN --version 2>&1))${NC}"
+"$PYTHON_BIN" dashboard/server.py &
 SERVER_PID=$!
 
 sleep 1


### PR DESCRIPTION
## Summary
- make `start.sh` automatically select a Python 3.10+ interpreter
- pass the selected interpreter through to `scripts/run_loop.sh`
- update README to match the project's actual Python requirement

## Problem
The repository README says Python 3.9+ is supported, and `start.sh` launches the dashboard with plain `python3`. On macOS systems where `python3` is still 3.9, startup fails immediately because the codebase already uses Python 3.10+ syntax such as `pathlib.Path | None`.

## Fix
This PR aligns the startup path and docs with the real runtime requirement:
- `start.sh` now looks for `EDICT_PYTHON`, then `python3.12`, `python3.11`, `python3.10`, and finally `python3`, accepting the first interpreter that is 3.10+
- the selected interpreter is exported and reused by `scripts/run_loop.sh`
- README now states Python 3.10+

## Reproduction
On a machine with `python3 = 3.9.x`, run:
```bash
chmod +x start.sh && ./start.sh
```
Startup fails during import with:
```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

## Validation
- verified startup succeeds with Python 3.11
- verified dashboard serves successfully on `http://127.0.0.1:7891/`
- verified the refresh loop uses the same interpreter selection path
