### PR TITLE
fix(dashboard): apply allowed_roots check to file:// URLs in add_remote_skill (CWE-22)

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -348,9 +348,13 @@ def add_remote_skill(agent_id, skill_name, source_url, description=''):
         
         elif source_url.startswith('file://'):
             # file:// URL 格式
-            local_path = pathlib.Path(source_url[7:])
+            local_path = pathlib.Path(source_url[7:]).resolve()
             if not local_path.exists():
                 return {'ok': False, 'error': f'本地文件不存在: {local_path}'}
+            # 路径遍历防护：与本地路径分支一致，确保在允许范围内
+            allowed_roots = (OCLAW_HOME.resolve(), BASE.parent.resolve())
+            if not any(str(local_path).startswith(str(root)) for root in allowed_roots):
+                return {'ok': False, 'error': '路径不在允许的目录范围内'}
             content = local_path.read_text()
         
         elif source_url.startswith('/') or source_url.startswith('.'):

--- a/tests/test_cwe22_file_url.py
+++ b/tests/test_cwe22_file_url.py
@@ -1,0 +1,102 @@
+"""
+PoC test: CWE-22 — Path traversal via file:// URL in add_remote_skill
+reads arbitrary local files without allowed_roots check.
+
+Expected: FAIL before fix, PASS after fix.
+"""
+import json, pathlib, sys, os, tempfile
+
+# Setup project paths
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+sys.path.insert(0, str(REPO_ROOT / 'dashboard'))
+sys.path.insert(0, str(REPO_ROOT / 'scripts'))
+
+
+def test_file_url_path_traversal_blocked(tmp_path):
+    """file:// URLs pointing outside allowed_roots must be rejected."""
+    import server as srv
+
+    # Create a fake data dir with agent_config
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    (data_dir / 'agent_config.json').write_text(json.dumps({
+        'agents': [{'id': 'testagent', 'skills': []}]
+    }))
+    srv.DATA = data_dir
+
+    # Create a temp OCLAW_HOME that doesn't contain the secret file
+    oclaw_home = tmp_path / '.openclaw'
+    oclaw_home.mkdir()
+    srv.OCLAW_HOME = oclaw_home
+
+    # Create a "secret" file outside any allowed root
+    secret_dir = tmp_path / 'secrets'
+    secret_dir.mkdir()
+    secret_file = secret_dir / 'SKILL.md'
+    # Must have valid frontmatter to pass content validation
+    secret_file.write_text('---\nname: evil\n---\nSECRET DATA\n')
+
+    # Attempt to read via file:// URL — this should be BLOCKED
+    result = srv.add_remote_skill('testagent', 'evilskill', f'file://{secret_file}')
+
+    # The fix should reject this because the path is outside allowed_roots
+    assert result['ok'] is False, (
+        f"VULNERABILITY: file:// URL read arbitrary file outside allowed_roots! "
+        f"Result: {result}"
+    )
+    assert '路径' in result.get('error', '') or 'allow' in result.get('error', '').lower(), (
+        f"Expected path restriction error, got: {result.get('error')}"
+    )
+
+
+def test_file_url_within_allowed_roots_works(tmp_path):
+    """file:// URLs within allowed_roots should still work after the fix."""
+    import server as srv
+
+    # Setup
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    (data_dir / 'agent_config.json').write_text(json.dumps({
+        'agents': [{'id': 'testagent', 'skills': []}]
+    }))
+    srv.DATA = data_dir
+
+    oclaw_home = tmp_path / '.openclaw'
+    oclaw_home.mkdir()
+    srv.OCLAW_HOME = oclaw_home
+
+    # Place a valid skill file inside OCLAW_HOME (an allowed root)
+    skill_src = oclaw_home / 'shared_skills' / 'goodskill'
+    skill_src.mkdir(parents=True)
+    good_file = skill_src / 'SKILL.md'
+    good_file.write_text('---\nname: goodskill\ndescription: a good skill\n---\n\n# Good Skill\n\nDoes good things.\n')
+
+    result = srv.add_remote_skill('testagent', 'goodskill', f'file://{good_file}')
+
+    assert result['ok'] is True, (
+        f"file:// URL within allowed_roots should work! Result: {result}"
+    )
+
+
+def test_file_url_etc_passwd_blocked(tmp_path):
+    """Classic /etc/passwd read via file:// must be blocked."""
+    import server as srv
+
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    (data_dir / 'agent_config.json').write_text(json.dumps({
+        'agents': [{'id': 'testagent', 'skills': []}]
+    }))
+    srv.DATA = data_dir
+
+    oclaw_home = tmp_path / '.openclaw'
+    oclaw_home.mkdir()
+    srv.OCLAW_HOME = oclaw_home
+
+    result = srv.add_remote_skill('testagent', 'readpasswd', 'file:///etc/passwd')
+
+    # Must be rejected (either file doesn't exist, or path not in allowed_roots)
+    assert result['ok'] is False, (
+        f"VULNERABILITY: file:// read /etc/passwd! Result: {result}"
+    )


### PR DESCRIPTION
## Summary

`add_remote_skill()` in `dashboard/server.py` accepts skill source URLs in several forms (http(s)://, file://, absolute/relative path). The bare-path branch correctly checks the resolved path against `allowed_roots` (`OCLAW_HOME` and the project root), but the `file://` branch had no such check. As a result, a `file:///etc/passwd`-style URL was read directly and the contents were imported as a "skill" into the workspace.

- **CWE**: CWE-22 (Improper Limitation of a Pathname to a Restricted Directory)
- **File / function**: `dashboard/server.py` → `add_remote_skill()` (the `elif source_url.startswith('file://')` branch, around line 350)
- **Severity**: High — arbitrary local file read for any file matching the SKILL.md frontmatter shape; result is persisted into the workspace where the attacker can retrieve it via the existing skill-listing/read APIs.
- **Data flow**: HTTP request body → `source_url` → `pathlib.Path(source_url[7:])` → `.read_text()` with no allow-list check.

## Fix

Mirror the guard already used by the sibling bare-path branch onto the `file://` branch:

```python
local_path = pathlib.Path(source_url[7:]).resolve()
if not local_path.exists():
    return {'ok': False, 'error': f'本地文件不存在: {local_path}'}
allowed_roots = (OCLAW_HOME.resolve(), BASE.parent.resolve())
if not any(str(local_path).startswith(str(root)) for root in allowed_roots):
    return {'ok': False, 'error': '路径不在允许的目录范围内'}
content = local_path.read_text()
```

Rationale: keeps both branches consistent, uses the same `allowed_roots` already trusted elsewhere in the file, and `resolve()` collapses `..` segments before the prefix check so traversal payloads like `file:///tmp/../etc/passwd` are normalized first.

The diff is minimal (4 added lines plus the `.resolve()` call), no behavior change for legitimate `file://` URLs that point inside `OCLAW_HOME` or the project tree.

## Tests

Added `tests/test_cwe22_file_url.py` with three regression tests:

1. `test_file_url_path_traversal_blocked` — `file://` URL pointing outside allowed roots is rejected.
2. `test_file_url_within_allowed_roots_works` — legitimate `file://` URL inside `OCLAW_HOME` still works.
3. `test_file_url_etc_passwd_blocked` — `file:///etc/passwd` is rejected.

Result locally:

```
tests/test_cwe22_file_url.py::test_file_url_path_traversal_blocked PASSED
tests/test_cwe22_file_url.py::test_file_url_within_allowed_roots_works PASSED
tests/test_cwe22_file_url.py::test_file_url_etc_passwd_blocked PASSED
3 passed in 0.11s
```

## Exploitability

The dashboard server currently prints `认证未配置，所有 API 公开访问` when no auth is configured, which is the default. In that mode, anyone who can reach the dashboard port (default `127.0.0.1`, but operators commonly bind to `0.0.0.0` or expose it via tunnels) can call `add_remote_skill` with a `file://` URL and read any local file whose contents parse as SKILL.md frontmatter — `/etc/passwd`, SSH keys, env files, application configs, etc. Even with auth enabled, the same call can be reached via CSRF against an authenticated user if CORS/SameSite settings are permissive, or by any local process running as a different user able to talk to the loopback port.

### Adversarial review

Before submitting, we tried to disprove this. We checked whether the bare-path branch's existing `allowed_roots` check would catch `file://` inputs first — it doesn't, dispatch is by URL scheme so `file://` skips it entirely. We checked whether auth is required by default — it isn't; the server explicitly logs that all APIs are public when no auth is configured. We checked whether the read is sandboxed at the OS level — there's no such sandbox; `pathlib.Path.read_text()` runs with full server privileges. The fix is the smallest change that closes the gap and matches the pattern already used in the same function.

cc @lewiswigmore
