### PR TITLE
fix(channels): block SSRF via generic webhook URL (CWE-918)

### DIFF
--- a/edict/backend/app/channels/base.py
+++ b/edict/backend/app/channels/base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import ipaddress
+import socket
 from typing import Protocol, ClassVar
 from abc import abstractmethod
 
@@ -33,3 +35,48 @@ class NotificationChannel(Protocol):
             return parsed.netloc.lower()
         except Exception:
             return ''
+
+    @classmethod
+    def _is_public_host(cls, url: str) -> bool:
+        """Return True only if the URL host resolves exclusively to public IPs.
+
+        Blocks SSRF vectors: loopback, link-local (incl. 169.254.169.254 cloud
+        metadata), private (RFC1918), multicast, reserved and unspecified
+        addresses, plus IPv6 equivalents.
+        """
+        try:
+            from urllib.parse import urlparse
+            parsed = urlparse(url)
+        except Exception:
+            return False
+        host = parsed.hostname
+        if not host:
+            return False
+        # Reject hosts that are already raw IP literals pointing at unsafe ranges
+        # plus any DNS name that resolves to one. We must check *all* resolved
+        # addresses, not just the first, to avoid bypass via multi-A records.
+        try:
+            infos = socket.getaddrinfo(host, None)
+        except socket.gaierror:
+            return False
+        if not infos:
+            return False
+        for info in infos:
+            sockaddr = info[4]
+            ip_str = sockaddr[0]
+            try:
+                ip = ipaddress.ip_address(ip_str)
+            except ValueError:
+                return False
+            if (ip.is_private or ip.is_loopback or ip.is_link_local
+                    or ip.is_multicast or ip.is_reserved
+                    or ip.is_unspecified):
+                return False
+            # Additionally block IPv4-mapped/compatible IPv6 to private space
+            if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+                mapped = ip.ipv4_mapped
+                if (mapped.is_private or mapped.is_loopback or mapped.is_link_local
+                        or mapped.is_multicast or mapped.is_reserved
+                        or mapped.is_unspecified):
+                    return False
+        return True

--- a/edict/backend/app/channels/webhook.py
+++ b/edict/backend/app/channels/webhook.py
@@ -17,10 +17,21 @@ class WebhookChannel(NotificationChannel):
 
     @classmethod
     def validate_webhook(cls, webhook: str) -> bool:
-        return cls._validate_url_scheme(webhook)
+        # Require HTTPS and that the destination resolves to a public IP only.
+        # Without this SSRF guard, the generic webhook channel would happily
+        # POST to internal services (e.g. http(s)://169.254.169.254/, RFC1918
+        # hosts, localhost) when an operator pastes such a URL into the
+        # notification config.
+        if not cls._validate_url_scheme(webhook):
+            return False
+        return cls._is_public_host(webhook)
 
     @classmethod
     def send(cls, webhook: str, title: str, content: str, url: str | None = None) -> bool:
+        # Re-validate at send time as a defence-in-depth measure against
+        # config tampering / DNS rebinding between validation and send.
+        if not cls.validate_webhook(webhook):
+            return False
         payload = json.dumps({
             'title': title,
             'content': content,

--- a/tests/test_webhook_ssrf.py
+++ b/tests/test_webhook_ssrf.py
@@ -1,0 +1,71 @@
+"""PoC test for CWE-918 SSRF in WebhookChannel."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "edict" / "backend"))
+
+from app.channels.webhook import WebhookChannel  # noqa: E402
+
+
+def _patch_dns(host_to_ip):
+    def fake_getaddrinfo(host, *_a, **_k):
+        ip = host_to_ip.get(host)
+        if ip is None:
+            import socket
+            raise socket.gaierror('mock')
+        return [(2, 1, 6, '', (ip, 0))]
+    return mock.patch('app.channels.base.socket.getaddrinfo',
+                      side_effect=fake_getaddrinfo)
+
+
+def test_blocks_loopback():
+    with _patch_dns({'127.0.0.1': '127.0.0.1', 'localhost': '127.0.0.1'}):
+        assert WebhookChannel.validate_webhook('https://127.0.0.1/x') is False
+        assert WebhookChannel.validate_webhook('https://localhost/x') is False
+
+
+def test_blocks_cloud_metadata():
+    with _patch_dns({'169.254.169.254': '169.254.169.254',
+                     'metadata.google.internal': '169.254.169.254'}):
+        assert WebhookChannel.validate_webhook('https://169.254.169.254/latest/meta-data/') is False
+        assert WebhookChannel.validate_webhook('https://metadata.google.internal/') is False
+
+
+def test_blocks_rfc1918():
+    with _patch_dns({'10.0.0.5': '10.0.0.5',
+                     '192.168.1.1': '192.168.1.1',
+                     '172.16.0.1': '172.16.0.1'}):
+        assert WebhookChannel.validate_webhook('https://10.0.0.5/x') is False
+        assert WebhookChannel.validate_webhook('https://192.168.1.1/x') is False
+        assert WebhookChannel.validate_webhook('https://172.16.0.1/x') is False
+
+
+def test_blocks_http_scheme():
+    assert WebhookChannel.validate_webhook('http://example.com/x') is False
+
+
+def test_allows_public_host():
+    with _patch_dns({'example.com': '93.184.216.34'}):
+        assert WebhookChannel.validate_webhook('https://example.com/hook') is True
+
+
+def test_send_refuses_unsafe_url():
+    with _patch_dns({'127.0.0.1': '127.0.0.1'}):
+        with mock.patch('app.channels.webhook.urlopen') as uo:
+            ok = WebhookChannel.send('https://127.0.0.1/x', 't', 'c')
+            assert ok is False
+            uo.assert_not_called()
+
+
+if __name__ == '__main__':
+    test_blocks_loopback()
+    test_blocks_cloud_metadata()
+    test_blocks_rfc1918()
+    test_blocks_http_scheme()
+    test_allows_public_host()
+    test_send_refuses_unsafe_url()
+    print('OK')


### PR DESCRIPTION
Closes #317

## Summary

The generic `WebhookChannel` (`edict/backend/app/channels/webhook.py`) validates a configured webhook URL only for scheme. Any user who can edit the notification webhook in the dashboard config can therefore point it at internal addresses — loopback, RFC1918, link-local (including cloud metadata at `169.254.169.254`) — and the server will dutifully POST the morning-brief payload to them on each scheduled push.

This is a server-side request forgery primitive (CWE-918). It's bounded — the request method is fixed POST, body is a fixed JSON shape, and the existing scheme check already forces HTTPS so plain-HTTP IMDSv1 endpoints aren't directly hit — but it still gives an authenticated operator (or anyone, in default deployments without a dashboard password) a way to probe internal HTTPS services and to reach internal webhook receivers they otherwise have no network path to.

**Affected:** `WebhookChannel.validate_webhook` / `WebhookChannel.send` in `edict/backend/app/channels/webhook.py`.

**Data flow:** `morning_brief_config.webhook` (operator-controlled) → `WebhookChannel.validate_webhook` (scheme-only) → `urlopen(Request(webhook, …))` in `WebhookChannel.send`.

## Fix

Two small changes:

1. Add `NotificationChannel._is_public_host(url)` in `edict/backend/app/channels/base.py`. It resolves the URL host via `socket.getaddrinfo` and rejects the URL if **any** resolved address is loopback, link-local, private, multicast, reserved, or unspecified — for both IPv4 and IPv6, including IPv4-mapped IPv6 (`::ffff:127.0.0.1`-style) which is a common bypass.
2. Have `WebhookChannel.validate_webhook` call both the scheme check and `_is_public_host`, and re-run `validate_webhook` inside `send()` as defence-in-depth against config tampering between validation and send.

Rationale for putting the helper on the base class: other channels that accept user-controlled URLs in the future can opt in by calling the same helper, rather than each re-implementing the IP checks.

## Tests

Added `tests/test_webhook_ssrf.py` with six cases (DNS mocked so the suite is hermetic):

- loopback (`https://127.0.0.1`, `https://localhost`) → rejected
- cloud metadata (`https://169.254.169.254/...`, `https://metadata.google.internal/`) → rejected
- RFC1918 (`10.0.0.5`, `192.168.1.1`, `172.16.0.1`) → rejected
- `http://` scheme → rejected (existing check)
- public host (`example.com` → `93.184.216.34`) → accepted
- `send()` to an unsafe URL never calls `urlopen`

All pass:

```
$ python3 tests/test_webhook_ssrf.py
OK
```

## Security analysis

Preconditions to exploit:
- Ability to write `morning_brief_config.webhook` — i.e. dashboard admin, or any unauthenticated user in deployments where no dashboard password is set (the default).
- The push notification job actually fires (scheduled task or manual trigger).

What an attacker gains without the fix:
- Blind SSRF: trigger an HTTPS POST with a fixed JSON body to any reachable host:port from the server's network position. Useful for internal port/service probing (response timing / error differentiation), reaching internal webhook receivers, or hitting internal HTTPS admin panels that act on POST.
- Note: the pre-existing HTTPS-only check does already block plain-HTTP cloud metadata (AWS IMDSv1, GCP, Azure all require HTTP), which limits the worst case. The fix still adds value by closing the broader internal-network reachability primitive.

What the fix prevents:
- All loopback, link-local (incl. metadata), RFC1918, multicast, reserved and unspecified addresses are rejected at config-validation time and again at send time.

Known limitation (worth flagging honestly): validation and `urlopen` each resolve DNS independently, so a perfectly-timed DNS rebind between the two resolutions could still slip past. Full rebinding immunity would require resolving once and connecting by the resolved IP (with `Host` header preserved). Given the preconditions already require write-access to the webhook config, this residual risk is small; happy to follow up with a resolve-then-connect variant if you'd like.

## Adversarial review

Before submitting, we tried to disprove this. The main questions were: (a) does the existing HTTPS-only check already kill the interesting targets — no, it blocks HTTP IMDS endpoints but not internal HTTPS services or internal webhook receivers; (b) does requiring admin access make this redundant with what the admin can already do — dashboard admin grants config write but not arbitrary outbound POST capability from the server's network position, and in default deployments the dashboard has no password set at all, so the precondition is weak; (c) does any framework-level egress filter exist — there isn't one in the repo. So the finding stands.