### PR TITLE
feat: add MiniMax models to Model Config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Syntax check (py_compile)
         run: |
-          find scripts dashboard -name '*.py' | while read f; do
+          find scripts dashboard -type f -name '*.py' | while read f; do
             echo "  checking $f"
             python3 -m py_compile "$f"
           done
@@ -109,7 +109,7 @@ jobs:
 
       - name: Syntax check (py_compile)
         run: |
-          find edict/backend -name '*.py' | while read f; do
+          find edict/backend -type f -name '*.py' | while read f; do
             echo "  checking $f"
             python3 -m py_compile "$f"
           done

--- a/README_EN.md
+++ b/README_EN.md
@@ -245,6 +245,8 @@ bash edict.sh stop     # Stop
 </details>
 
 > 📖 See [Getting Started Guide](docs/getting-started.md) for detailed walkthrough.
+>
+> Configure MiniMax before selecting it in Model Config: [MiniMax Provider Setup](docs/minimax-provider-setup.md).
 
 ---
 

--- a/docs/minimax-provider-setup.md
+++ b/docs/minimax-provider-setup.md
@@ -1,0 +1,60 @@
+# MiniMax Provider Setup
+
+Edict's Model Config includes `minimax/MiniMax-M3` and `minimax/MiniMax-M2.7`. Configure the `minimax` provider in OpenClaw before assigning either model to an agent.
+
+## Authenticate
+
+Use the OpenClaw model authentication flow for your region:
+
+```bash
+# Global endpoint
+openclaw onboard --auth-choice minimax-global-api
+
+# China endpoint
+openclaw onboard --auth-choice minimax-cn-api
+```
+
+Run only the command for the region you use. OpenClaw stores the API key in its credential store; Edict does not read or persist the key.
+
+## Select the Endpoint and Protocol
+
+Run one matching command pair. Each pair updates the existing `minimax` provider without replacing other configured models.
+
+### Global OpenAI-compatible
+
+```bash
+openclaw config set models.providers.minimax.baseUrl https://api.minimax.io/v1
+openclaw config set models.providers.minimax.api openai-completions
+```
+
+### Global Anthropic-compatible
+
+```bash
+openclaw config set models.providers.minimax.baseUrl https://api.minimax.io/anthropic
+openclaw config set models.providers.minimax.api anthropic-messages
+```
+
+### China OpenAI-compatible
+
+```bash
+openclaw config set models.providers.minimax.baseUrl https://api.minimaxi.com/v1
+openclaw config set models.providers.minimax.api openai-completions
+```
+
+### China Anthropic-compatible
+
+```bash
+openclaw config set models.providers.minimax.baseUrl https://api.minimaxi.com/anthropic
+openclaw config set models.providers.minimax.api anthropic-messages
+```
+
+Keep the Anthropic-compatible base URL ending in `/anthropic`. The client appends the Messages API request path.
+
+## Verify
+
+```bash
+openclaw models list --provider minimax
+openclaw gateway restart
+```
+
+After the gateway restarts, open Edict's Model Config and select `MiniMax M3` or `MiniMax M2.7` for an agent.

--- a/scripts/sync_agent_config.py
+++ b/scripts/sync_agent_config.py
@@ -46,6 +46,8 @@ KNOWN_MODELS = [
     {'id': 'copilot/gpt-4o',              'label': 'GPT-4o',            'provider': 'Copilot'},
     {'id': 'copilot/gemini-2.5-pro',      'label': 'Gemini 2.5 Pro',    'provider': 'Copilot'},
     {'id': 'copilot/o3-mini',             'label': 'o3-mini',           'provider': 'Copilot'},
+    {'id': 'minimax/MiniMax-M3',          'label': 'MiniMax M3',        'provider': 'MiniMax'},
+    {'id': 'minimax/MiniMax-M2.7',        'label': 'MiniMax M2.7',      'provider': 'MiniMax'},
 ]
 
 

--- a/tests/test_minimax_model_config.py
+++ b/tests/test_minimax_model_config.py
@@ -1,0 +1,81 @@
+import importlib.util
+import json
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+
+def _load_court_discuss():
+    root = Path(__file__).resolve().parents[1]
+    module_path = root / "dashboard" / "court_discuss.py"
+    spec = importlib.util.spec_from_file_location("court_discuss", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Response:
+    def __init__(self, payload):
+        self.payload = json.dumps(payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self):
+        return self.payload
+
+
+@pytest.mark.parametrize(
+    ("base_url", "api_type", "expected_url"),
+    [
+        (
+            "https://api.minimax.io/v1",
+            "openai-completions",
+            "https://api.minimax.io/v1/chat/completions",
+        ),
+        (
+            "https://api.minimax.io/anthropic",
+            "anthropic-messages",
+            "https://api.minimax.io/anthropic/v1/messages",
+        ),
+        (
+            "https://api.minimaxi.com/v1",
+            "openai-completions",
+            "https://api.minimaxi.com/v1/chat/completions",
+        ),
+        (
+            "https://api.minimaxi.com/anthropic",
+            "anthropic-messages",
+            "https://api.minimaxi.com/anthropic/v1/messages",
+        ),
+    ],
+)
+def test_minimax_request_paths(base_url, api_type, expected_url, monkeypatch):
+    court_discuss = _load_court_discuss()
+    captured = {}
+
+    monkeypatch.setattr(
+        court_discuss,
+        "_get_llm_config",
+        lambda: {
+            "api_key": "test-key",
+            "base_url": base_url,
+            "model": "MiniMax-M3",
+            "api_type": api_type,
+        },
+    )
+
+    def capture_request(request, timeout):
+        captured["url"] = request.full_url
+        if api_type == "anthropic-messages":
+            return _Response({"content": [{"text": "ok"}]})
+        return _Response({"choices": [{"message": {"content": "ok"}}]})
+
+    monkeypatch.setattr(urllib.request, "urlopen", capture_request)
+
+    assert court_discuss._llm_complete("system", "user") == "ok"
+    assert captured["url"] == expected_url

--- a/tests/test_sync_agent_config.py
+++ b/tests/test_sync_agent_config.py
@@ -1,5 +1,6 @@
 import json
 import importlib.util
+import sys
 from pathlib import Path
 
 
@@ -8,7 +9,11 @@ def _load_sync_agent_config():
     script_path = root / "scripts" / "sync_agent_config.py"
     spec = importlib.util.spec_from_file_location("sync_agent_config", script_path)
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    sys.path.insert(0, str(script_path.parent))
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(script_path.parent))
     return module
 
 
@@ -39,3 +44,19 @@ def test_sync_agent_config_accepts_allow_agents_key(tmp_path, monkeypatch):
     out = json.loads((tmp_path / "data" / "agent_config.json").read_text())
     taizi = next(agent for agent in out["agents"] if agent["id"] == "taizi")
     assert taizi["allowAgents"] == ["zhongshu"]
+
+
+def test_known_models_include_minimax_text_models():
+    sync_agent_config = _load_sync_agent_config()
+    models = {model["id"]: model for model in sync_agent_config.KNOWN_MODELS}
+
+    assert models["minimax/MiniMax-M3"] == {
+        "id": "minimax/MiniMax-M3",
+        "label": "MiniMax M3",
+        "provider": "MiniMax",
+    }
+    assert models["minimax/MiniMax-M2.7"] == {
+        "id": "minimax/MiniMax-M2.7",
+        "label": "MiniMax M2.7",
+        "provider": "MiniMax",
+    }


### PR DESCRIPTION
Reason: Add the target provider and models to the existing provider registry.

## Summary
- Register MiniMax M3 and MiniMax M2.7 in the model selector data.
- Document global and China endpoint setup for both supported API protocols.
- Add registry and request-path coverage for all supported endpoint combinations.

## Checks
- `python3 -m py_compile scripts/sync_agent_config.py dashboard/court_discuss.py tests/test_sync_agent_config.py tests/test_minimax_model_config.py`
- `.venv/bin/python -m pytest tests/test_sync_agent_config.py tests/test_minimax_model_config.py -v` (6 passed)
- `.venv/bin/python -m pytest tests/ -v` (66 passed, 7 unrelated existing failures in kanban and symlink tests)
- Parameter consistency assertions for both model IDs and all regional endpoints
- `git diff --check`