### PR TITLE
fix: atomically finalize returned tasks

### DIFF
--- a/agents/taizi/SOUL.md
+++ b/agents/taizi/SOUL.md
@@ -91,9 +91,9 @@ python3 scripts/kanban_update.py flow JJC-xxx "太子" "中书省" "📋 旨意�
 
 当中书省完成门下审议与尚书执行整条链路，并返回最终结果后，太子必须：
 1. 在飞书**原对话**中回复皇上完整结果
-2. 更新看板：
+2. 使用原子收口命令更新看板（重复执行不会重复记录）：
 ```bash
-python3 scripts/kanban_update.py flow JJC-xxx "太子" "皇上" "✅ 回奏皇上：[摘要]"
+python3 scripts/kanban_update.py complete JJC-xxx "[摘要]"
 ```
 
 ---

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -1099,6 +1099,56 @@ def _scheduler_mark_progress(task, note=''):
         _scheduler_add_flow(task, f'进展确认：{note}')
 
 
+def _final_reply_entry(task):
+    """Return the latest completed 太子 → 皇上 reply, if it is safe to close."""
+    todos = task.get('todos') or []
+    if any(
+        not isinstance(todo, dict) or todo.get('status') != 'completed'
+        for todo in todos
+    ):
+        return None
+
+    flow_log = task.get('flow_log') or []
+    if not isinstance(flow_log, list):
+        return None
+    return next((
+        entry for entry in reversed(flow_log)
+        if isinstance(entry, dict)
+        and str(entry.get('from', '')).strip() == '太子'
+        and str(entry.get('to', '')).strip() == '皇上'
+        and (
+            entry.get('kind') == 'completion'
+            or str(entry.get('remark', '')).lstrip().startswith('✅ 回奏皇上')
+        )
+    ), None)
+
+
+def _finalize_returned_task(task):
+    """Heal a legacy final reply into the terminal scheduler state."""
+    final_entry = _final_reply_entry(task)
+    if final_entry is None:
+        return False
+
+    completed_at = final_entry.get('at') or task.get('updatedAt') or now_iso()
+    task['state'] = 'Done'
+    task['org'] = '皇上'
+    task['now'] = final_entry.get('remark') or '✅ 已回奏皇上'
+    task['block'] = '无'
+    task['completedAt'] = task.get('completedAt') or completed_at
+    task['updatedAt'] = now_iso()
+    sched = _ensure_scheduler(task)
+    sched.update({
+        'enabled': False,
+        'stallSince': None,
+        'retryCount': 0,
+        'escalationLevel': 0,
+        'lastProgressAt': task['completedAt'],
+        'lastDispatchStatus': 'completed',
+        'lastDispatchTrigger': 'taizi-final-reply',
+    })
+    return True
+
+
 def _resolve_openclaw_bin():
     """Return the OpenClaw CLI path used by dashboard dispatch.
 
@@ -1154,24 +1204,27 @@ def handle_scheduler_retry(task_id, reason=''):
     if not task:
         return {'ok': False, 'error': f'任务 {task_id} 不存在'}
     state = task.get('state', '')
-    if state in _TERMINAL_STATES or state == 'Blocked':
+    if state in _TERMINAL_STATES or state == 'Blocked' or _final_reply_entry(task):
         return {'ok': False, 'error': f'任务 {task_id} 当前状态 {state} 不支持重试'}
 
-    result = {'retryCount': 0, 'state': state}
+    result = {'applied': False, 'retryCount': 0, 'state': state}
 
     def _apply(task):
         cur = task.get('state', '')
-        if cur in _TERMINAL_STATES or cur == 'Blocked':
+        if cur in _TERMINAL_STATES or cur == 'Blocked' or _final_reply_entry(task):
             return  # state changed between pre-check and lock; skip
         sched = _ensure_scheduler(task)
         sched['retryCount'] = int(sched.get('retryCount') or 0) + 1
         sched['lastRetryAt'] = now_iso()
         sched['lastDispatchTrigger'] = 'taizi-retry'
         _scheduler_add_flow(task, f'触发重试第{sched["retryCount"]}次：{reason or "超时未推进"}')
+        result['applied'] = True
         result['retryCount'] = sched['retryCount']
         result['state'] = cur
 
     modify_task(task_id, _apply)
+    if not result['applied']:
+        return {'ok': False, 'error': f'任务 {task_id} 已结束，无需重试'}
 
     dispatch_for_state(task_id, task, result['state'], trigger='taizi-retry')
     return {'ok': True, 'message': f'{task_id} 已触发重试派发', 'retryCount': result['retryCount']}
@@ -1183,32 +1236,52 @@ def handle_scheduler_escalate(task_id, reason=''):
     if not task:
         return {'ok': False, 'error': f'任务 {task_id} 不存在'}
     state = task.get('state', '')
-    if state in _TERMINAL_STATES:
+    if state in _TERMINAL_STATES or _final_reply_entry(task):
         return {'ok': False, 'error': f'任务 {task_id} 已结束，无需升级'}
 
-    sched = _ensure_scheduler(task)
-    current_level = int(sched.get('escalationLevel') or 0)
-    next_level = min(current_level + 1, 2)
-    target = 'menxia' if next_level == 1 else 'shangshu'
-    target_label = '门下省' if next_level == 1 else '尚书省'
+    result = {'applied': False, 'state': state, 'level': 0, 'target': '', 'target_label': ''}
 
-    sched['escalationLevel'] = next_level
-    sched['lastEscalatedAt'] = now_iso()
-    _scheduler_add_flow(task, f'升级到{target_label}协调：{reason or "任务停滞"}', to=target_label)
-    task['updatedAt'] = now_iso()
-    save_tasks(tasks)
+    def _apply(task):
+        cur = task.get('state', '')
+        if cur in _TERMINAL_STATES or _final_reply_entry(task):
+            return
+        sched = _ensure_scheduler(task)
+        current_level = int(sched.get('escalationLevel') or 0)
+        next_level = min(current_level + 1, 2)
+        target = 'menxia' if next_level == 1 else 'shangshu'
+        target_label = '门下省' if next_level == 1 else '尚书省'
+        sched['escalationLevel'] = next_level
+        sched['lastEscalatedAt'] = now_iso()
+        _scheduler_add_flow(task, f'升级到{target_label}协调：{reason or "任务停滞"}', to=target_label)
+        result.update({
+            'applied': True,
+            'state': cur,
+            'level': next_level,
+            'target': target,
+            'target_label': target_label,
+        })
+
+    modify_task(task_id, _apply)
+    if not result['applied']:
+        return {'ok': False, 'error': f'任务 {task_id} 已结束，无需升级'}
 
     msg = (
         f'🧭 太子调度升级通知\n'
         f'任务ID: {task_id}\n'
-        f'当前状态: {state}\n'
+        f'当前状态: {result["state"]}\n'
         f'停滞处理: 请你介入协调推进\n'
         f'原因: {reason or "任务超过阈值未推进"}\n'
         f'⚠️ 看板已有任务，请勿重复创建。'
     )
-    wake_agent(target, msg)
+    if not _dispatch_is_current(task_id, result['state']):
+        return {'ok': False, 'error': f'任务 {task_id} 已结束，无需升级'}
+    wake_agent(result['target'], msg)
 
-    return {'ok': True, 'message': f'{task_id} 已升级至{target_label}', 'escalationLevel': next_level}
+    return {
+        'ok': True,
+        'message': f'{task_id} 已升级至{result["target_label"]}',
+        'escalationLevel': result['level'],
+    }
 
 
 def handle_scheduler_rollback(task_id, reason=''):
@@ -1217,15 +1290,19 @@ def handle_scheduler_rollback(task_id, reason=''):
     task = next((t for t in tasks if t.get('id') == task_id), None)
     if not task:
         return {'ok': False, 'error': f'任务 {task_id} 不存在'}
+    if task.get('state', '') in _TERMINAL_STATES or _final_reply_entry(task):
+        return {'ok': False, 'error': f'任务 {task_id} 已结束，无需回滚'}
     sched = _ensure_scheduler(task)
     snapshot = sched.get('snapshot') or {}
     snap_state = snapshot.get('state')
     if not snap_state:
         return {'ok': False, 'error': f'任务 {task_id} 无可用回滚快照'}
 
-    result = {'snap_state': snap_state}
+    result = {'applied': False, 'snap_state': snap_state}
 
     def _apply(task):
+        if task.get('state', '') in _TERMINAL_STATES or _final_reply_entry(task):
+            return
         sched = _ensure_scheduler(task)
         snapshot = sched.get('snapshot') or {}
         s_state = snapshot.get('state')
@@ -1241,9 +1318,13 @@ def handle_scheduler_rollback(task_id, reason=''):
         sched['stallSince'] = None
         sched['lastProgressAt'] = now_iso()
         _scheduler_add_flow(task, f'执行回滚：{old_state} → {s_state}，原因：{reason or "停滞恢复"}')
+        result['applied'] = True
         result['snap_state'] = s_state
 
     modify_task(task_id, _apply)
+
+    if not result['applied']:
+        return {'ok': False, 'error': f'任务 {task_id} 已结束，无需回滚'}
 
     if result['snap_state'] not in _TERMINAL_STATES:
         dispatch_for_state(task_id, task, result['snap_state'], trigger='taizi-rollback')
@@ -1277,10 +1358,15 @@ def handle_scheduler_scan(threshold_sec=600):
             state = task.get('state', '')
             if not task_id or state in _TERMINAL_STATES or task.get('archived'):
                 continue
+            if _finalize_returned_task(task):
+                changed = True
+                continue
             if state == 'Blocked':
                 continue
 
             sched = _ensure_scheduler(task)
+            if sched.get('enabled') is False:
+                continue
             task_threshold = int(sched.get('stallThresholdSec') or threshold_sec)
             last_progress = _parse_iso(sched.get('lastProgressAt') or task.get('updatedAt'))
             if not last_progress:
@@ -1362,10 +1448,25 @@ def handle_scheduler_scan(threshold_sec=600):
 
     for task_id, state in pending_retries:
         retry_task = next((t for t in tasks if t.get('id') == task_id), None)
-        if retry_task:
+        retry_sched = (retry_task or {}).get('_scheduler') or {}
+        if (
+            retry_task
+            and retry_task.get('state') == state
+            and state not in _TERMINAL_STATES
+            and retry_sched.get('enabled') is not False
+        ):
             dispatch_for_state(task_id, retry_task, state, trigger='taizi-scan-retry')
 
     for task_id, state, target, target_label, stalled_sec in pending_escalates:
+        current_task = next((t for t in tasks if t.get('id') == task_id), None)
+        current_sched = (current_task or {}).get('_scheduler') or {}
+        if (
+            not current_task
+            or current_task.get('state') != state
+            or state in _TERMINAL_STATES
+            or current_sched.get('enabled') is False
+        ):
+            continue
         msg = (
             f'🧭 太子调度升级通知\n'
             f'任务ID: {task_id}\n'
@@ -1378,7 +1479,13 @@ def handle_scheduler_scan(threshold_sec=600):
 
     for task_id, state in pending_rollbacks:
         rollback_task = next((t for t in tasks if t.get('id') == task_id), None)
-        if rollback_task and state not in _TERMINAL_STATES:
+        rollback_sched = (rollback_task or {}).get('_scheduler') or {}
+        if (
+            rollback_task
+            and rollback_task.get('state') == state
+            and state not in _TERMINAL_STATES
+            and rollback_sched.get('enabled') is not False
+        ):
             dispatch_for_state(task_id, rollback_task, state, trigger='taizi-auto-rollback')
 
     return {
@@ -1399,6 +1506,8 @@ def _startup_recover_queued_dispatches():
         task_id = task.get('id', '')
         state = task.get('state', '')
         if not task_id or state in _TERMINAL_STATES or task.get('archived'):
+            continue
+        if _final_reply_entry(task):
             continue
         sched = task.get('_scheduler') or {}
         if sched.get('lastDispatchStatus') == 'queued':
@@ -2111,6 +2220,41 @@ _STATE_LABELS = {
 }
 
 
+def _task_accepts_dispatch(task, expected_state):
+    """Return whether a task still matches a queued dispatch."""
+    if not task or task.get('state') != expected_state or task.get('archived'):
+        return False
+    if expected_state in _TERMINAL_STATES or expected_state == 'Blocked':
+        return False
+    sched = task.get('_scheduler') or {}
+    if isinstance(sched, dict) and sched.get('enabled') is False:
+        return False
+    return _final_reply_entry(task) is None
+
+
+def _update_current_dispatch(task_id, expected_state, updater):
+    """Apply a dispatch mutation only while the task is still dispatchable."""
+    applied = [False]
+
+    def _apply(tasks):
+        task = next((t for t in tasks if t.get('id') == task_id), None)
+        if not _task_accepts_dispatch(task, expected_state):
+            return tasks
+        sched = _ensure_scheduler(task)
+        updater(task, sched)
+        task['updatedAt'] = now_iso()
+        applied[0] = True
+        return tasks
+
+    modify_tasks(_apply)
+    return applied[0]
+
+
+def _dispatch_is_current(task_id, expected_state):
+    task = next((t for t in load_tasks() if t.get('id') == task_id), None)
+    return _task_accepts_dispatch(task, expected_state)
+
+
 def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
     """推进/审批后自动派发对应 Agent（后台异步，不阻塞响应）。"""
     agent_id = _STATE_AGENT_MAP.get(new_state)
@@ -2121,7 +2265,7 @@ def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
         log.info(f'ℹ️ {task_id} 新状态 {new_state} 无对应 Agent，跳过自动派发')
         return
 
-    _update_task_scheduler(task_id, lambda t, s: (
+    queued = _update_current_dispatch(task_id, new_state, lambda t, s: (
         s.update({
             'lastDispatchAt': now_iso(),
             'lastDispatchStatus': 'queued',
@@ -2130,6 +2274,9 @@ def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
         }),
         _scheduler_add_flow(t, f'已入队派发：{new_state} → {agent_id}（{trigger}）', to=_STATE_LABELS.get(new_state, new_state))
     ))
+    if not queued:
+        log.info(f'ℹ️ {task_id} 状态已变化或调度已关闭，取消派发 {new_state} → {agent_id}')
+        return
 
     title = task.get('title', '(无标题)')
     target_dept = task.get('targetDept', '')
@@ -2175,6 +2322,9 @@ def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
 
     def _do_dispatch():
         try:
+            if not _dispatch_is_current(task_id, new_state):
+                log.info(f'ℹ️ {task_id} 状态已变化或调度已关闭，取消后台派发')
+                return
             # Gateway 可能暂时不可达（休眠恢复、进程重启），等待后重试
             import time as _time
             _gw_alive = False
@@ -2186,7 +2336,7 @@ def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
                     _time.sleep(5 * (_gw_attempt + 1))  # 5s, 10s
             if not _gw_alive:
                 log.warning(f'⚠️ {task_id} 自动派发跳过: Gateway 未启动（重试3次仍不可达）')
-                _update_task_scheduler(task_id, lambda t, s: s.update({
+                _update_current_dispatch(task_id, new_state, lambda t, s: s.update({
                     'lastDispatchAt': now_iso(),
                     'lastDispatchStatus': 'gateway-offline',
                     'lastDispatchAgent': agent_id,
@@ -2201,7 +2351,7 @@ def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
             if not openclaw_bin:
                 err = 'OpenClaw CLI 未找到：请确认已安装 openclaw 并加入 PATH；Windows 可设置 OPENCLAW_BIN 指向 openclaw.cmd'
                 log.warning(f'⚠️ {task_id} 自动派发异常: {err}')
-                _update_task_scheduler(task_id, lambda t, s: (
+                _update_current_dispatch(task_id, new_state, lambda t, s: (
                     s.update({
                         'lastDispatchAt': now_iso(),
                         'lastDispatchStatus': 'openclaw-missing',
@@ -2218,11 +2368,14 @@ def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
             max_retries = 2
             err = ''
             for attempt in range(1, max_retries + 1):
+                if not _dispatch_is_current(task_id, new_state):
+                    log.info(f'ℹ️ {task_id} 状态已变化或调度已关闭，取消后台派发')
+                    return
                 log.info(f'🔄 自动派发 {task_id} → {agent_id} (第{attempt}次)...')
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=310)
                 if result.returncode == 0:
                     log.info(f'✅ {task_id} 自动派发成功 → {agent_id}')
-                    _update_task_scheduler(task_id, lambda t, s: (
+                    _update_current_dispatch(task_id, new_state, lambda t, s: (
                         s.update({
                             'lastDispatchAt': now_iso(),
                             'lastDispatchStatus': 'success',
@@ -2239,7 +2392,7 @@ def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
                     import time
                     time.sleep(5)
             log.error(f'❌ {task_id} 自动派发最终失败 → {agent_id}')
-            _update_task_scheduler(task_id, lambda t, s: (
+            _update_current_dispatch(task_id, new_state, lambda t, s: (
                 s.update({
                     'lastDispatchAt': now_iso(),
                     'lastDispatchStatus': 'failed',
@@ -2251,7 +2404,7 @@ def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
             ))
         except subprocess.TimeoutExpired:
             log.error(f'❌ {task_id} 自动派发超时 → {agent_id}')
-            _update_task_scheduler(task_id, lambda t, s: (
+            _update_current_dispatch(task_id, new_state, lambda t, s: (
                 s.update({
                     'lastDispatchAt': now_iso(),
                     'lastDispatchStatus': 'timeout',
@@ -2264,7 +2417,7 @@ def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
         except FileNotFoundError as e:
             err = f'OpenClaw CLI 未找到：{e}'
             log.warning(f'⚠️ {task_id} 自动派发异常: {err}')
-            _update_task_scheduler(task_id, lambda t, s: (
+            _update_current_dispatch(task_id, new_state, lambda t, s: (
                 s.update({
                     'lastDispatchAt': now_iso(),
                     'lastDispatchStatus': 'openclaw-missing',
@@ -2276,7 +2429,7 @@ def dispatch_for_state(task_id, task, new_state, trigger='state-transition'):
             ))
         except Exception as e:
             log.warning(f'⚠️ {task_id} 自动派发异常: {e}')
-            _update_task_scheduler(task_id, lambda t, s: (
+            _update_current_dispatch(task_id, new_state, lambda t, s: (
                 s.update({
                     'lastDispatchAt': now_iso(),
                     'lastDispatchStatus': 'error',

--- a/scripts/kanban_update.py
+++ b/scripts/kanban_update.py
@@ -22,6 +22,9 @@
   # 完成任务
   python3 kanban_update.py done JJC-20260223-012 "/path/to/output" "任务完成摘要"
 
+  # 最终回奏并关闭调度
+  python3 kanban_update.py complete JJC-20260223-012 "最终回奏摘要"
+
   # 添加/更新子任务 todo
   python3 kanban_update.py todo JJC-20260223-012 1 "实现API接口" in-progress
   python3 kanban_update.py todo JJC-20260223-012 1 "" completed
@@ -160,7 +163,7 @@ def _append_audit(task_id, agent, action, old_val=None, new_val=None, reason="")
 
 # ── 越权检测（Agent 权限策略）──
 AGENT_POLICY = {
-    "taizi":    {"role": "coordination", "commands": {"create", "state", "flow", "progress", "todo", "memory", "task-memo"}},
+    "taizi":    {"role": "coordination", "commands": {"create", "state", "flow", "complete", "progress", "todo", "memory", "task-memo"}},
     "zhongshu": {"role": "coordination", "commands": {"state", "flow", "progress", "todo", "memory", "task-memo", "delegate"}},
     "menxia":   {"role": "coordination", "commands": {"state", "flow", "progress", "todo", "confirm", "memory", "task-memo"}},
     "shangshu": {"role": "coordination", "commands": {"state", "flow", "progress", "todo", "confirm", "delegate", "memory", "task-memo", "shared-memo"}},
@@ -435,6 +438,100 @@ def cmd_flow(task_id, from_dept, to_dept, remark):
     _trigger_refresh()
     log.info(f'✅ {task_id} 流转记录: {from_dept} → {to_dept}')
     _append_audit(task_id, _infer_agent_id_from_runtime(), 'flow', from_dept, to_dept, clean_remark)
+
+
+def cmd_complete(task_id, summary=''):
+    """原子、幂等地记录最终回奏并关闭任务调度。"""
+    clean_summary = _sanitize_remark(summary or '任务已完成')
+    agent_id = _infer_agent_id_from_runtime()
+    agent_label = _AGENT_LABELS.get(agent_id, agent_id)
+    changed = [False]
+    rejected = ['']
+
+    def modifier(tasks):
+        t = find_task(tasks, task_id)
+        if not t:
+            rejected[0] = f'任务 {task_id} 不存在'
+            return tasks
+        if t.get('state') == 'Cancelled':
+            rejected[0] = f'任务 {task_id} 已取消，不能回奏完结'
+            return tasks
+
+        completed, total = _todo_counts(t)
+        if total > 0 and completed < total:
+            rejected[0] = f'todos 未完成（{completed}/{total}），禁止回奏完结'
+            return tasks
+
+        flow_log = t.setdefault('flow_log', [])
+        final_entry = next((
+            entry for entry in reversed(flow_log)
+            if isinstance(entry, dict)
+            and str(entry.get('from', '')).strip() == '太子'
+            and str(entry.get('to', '')).strip() == '皇上'
+            and (
+                entry.get('kind') == 'completion'
+                or str(entry.get('remark', '')).lstrip().startswith('✅ 回奏皇上')
+            )
+        ), None)
+
+        sched = t.get('_scheduler')
+        if not isinstance(sched, dict):
+            sched = {}
+            t['_scheduler'] = sched
+        if (
+            t.get('state') == 'Done'
+            and t.get('org') == '皇上'
+            and t.get('completedAt')
+            and final_entry is not None
+            and sched.get('enabled') is False
+            and sched.get('lastDispatchStatus') == 'completed'
+        ):
+            return tasks
+
+        completed_at = t.get('completedAt') or (final_entry or {}).get('at') or now_iso()
+        if final_entry is None:
+            final_entry = {
+                'at': completed_at,
+                'from': '太子',
+                'to': '皇上',
+                'remark': f'✅ 回奏皇上：{clean_summary}',
+                'kind': 'completion',
+                'agent': agent_id,
+                'agentLabel': agent_label,
+            }
+            flow_log.append(final_entry)
+
+        t['state'] = 'Done'
+        t['org'] = '皇上'
+        t['now'] = final_entry.get('remark') or f'✅ 回奏皇上：{clean_summary}'
+        t['block'] = '无'
+        t['completedAt'] = completed_at
+        t['updatedAt'] = completed_at
+        sched.update({
+            'enabled': False,
+            'stallSince': None,
+            'retryCount': 0,
+            'escalationLevel': 0,
+            'lastProgressAt': completed_at,
+            'lastDispatchStatus': 'completed',
+            'lastDispatchTrigger': 'taizi-complete',
+        })
+        changed[0] = True
+        return tasks
+
+    atomic_json_update(TASKS_FILE, modifier, [])
+    if rejected[0]:
+        log.warning(f'⚠️ {task_id} complete 被拒绝：{rejected[0]}')
+        _append_audit(task_id, agent_id, 'complete_rejected', None, 'Done', rejected[0])
+        return False
+    if not changed[0]:
+        log.info(f'✅ {task_id} 已处于完成态，无需重复收口')
+        return True
+
+    _trigger_refresh()
+    log.info(f'✅ {task_id} 已回奏皇上并完成收口')
+    _append_audit(task_id, agent_id, 'complete', None, 'Done', clean_summary)
+    return True
 
 
 def cmd_done(task_id, output_path='', summary=''):
@@ -938,7 +1035,7 @@ def cmd_delegate_result(sub_task_id, result_json):
     _append_audit(parent_id, to_agent, 'delegate_result', sub_task_id, None, result_json[:100])
 
 _CMD_MIN_ARGS = {
-    'create': 6, 'state': 3, 'flow': 5, 'done': 2, 'block': 3, 'confirm': 3,
+    'create': 6, 'state': 3, 'flow': 5, 'complete': 2, 'done': 2, 'block': 3, 'confirm': 3,
     'todo': 4, 'progress': 3,
     'memory': 4, 'task-memo': 4, 'shared-memo': 3,
     'delegate': 5, 'delegate-result': 3,
@@ -962,6 +1059,8 @@ if __name__ == '__main__':
         cmd_state(args[1], args[2], args[3] if len(args)>3 else None)
     elif cmd == 'flow':
         cmd_flow(args[1], args[2], args[3], args[4])
+    elif cmd == 'complete':
+        cmd_complete(args[1], args[2] if len(args)>2 else '')
     elif cmd == 'done':
         cmd_done(args[1], args[2] if len(args)>2 else '', args[3] if len(args)>3 else '')
     elif cmd == 'block':

--- a/tests/test_task_mutation_race.py
+++ b/tests/test_task_mutation_race.py
@@ -43,6 +43,58 @@ def _setup_server(monkeypatch, tmp_path, tasks=None):
     return srv, data_dir, tasks_path
 
 
+def test_complete_atomically_finalizes_task_and_is_idempotent(monkeypatch, tmp_path):
+    """The documented final-reply command must also close scheduling state."""
+    import kanban_update as kb
+
+    tasks_path = tmp_path / 'tasks_source.json'
+    tasks_path.write_text(json.dumps([{
+        'id': 'T-FINAL-FLOW', 'title': '待回奏任务', 'state': 'Zhongshu',
+        'org': '中书省', 'todos': [],
+        'flow_log': [],
+        '_scheduler': {
+            'enabled': True, 'lastDispatchStatus': 'success',
+            'stallSince': '2026-04-22T02:00:00Z',
+        },
+    }], ensure_ascii=False), encoding='utf-8')
+    monkeypatch.setattr(kb, 'TASKS_FILE', tasks_path)
+    monkeypatch.setattr(kb, '_trigger_refresh', lambda: None)
+    monkeypatch.setattr(kb, '_append_audit', lambda *a, **kw: None)
+
+    assert kb.cmd_complete('T-FINAL-FLOW', '任务已完成') is True
+    first = json.loads(tasks_path.read_text(encoding='utf-8'))[0]
+    assert kb.cmd_complete('T-FINAL-FLOW', '不同的重复摘要') is True
+    task = json.loads(tasks_path.read_text(encoding='utf-8'))[0]
+
+    assert task == first
+    assert task['state'] == 'Done'
+    assert task['org'] == '皇上'
+    assert task['completedAt']
+    assert task['_scheduler']['enabled'] is False
+    assert task['_scheduler']['lastDispatchStatus'] == 'completed'
+    assert len(task['flow_log']) == 1
+    assert task['flow_log'][0]['kind'] == 'completion'
+
+
+def test_complete_rejects_incomplete_todos(monkeypatch, tmp_path):
+    """A final reply cannot bypass the existing todo completion gate."""
+    import kanban_update as kb
+
+    original = [{
+        'id': 'T-INCOMPLETE', 'title': '未完成任务', 'state': 'Doing',
+        'org': '工部', 'ready_to_close': True,
+        'todos': [{'id': '1', 'title': '执行', 'status': 'in-progress'}],
+        'flow_log': [],
+    }]
+    tasks_path = tmp_path / 'tasks_source.json'
+    tasks_path.write_text(json.dumps(original, ensure_ascii=False), encoding='utf-8')
+    monkeypatch.setattr(kb, 'TASKS_FILE', tasks_path)
+    monkeypatch.setattr(kb, '_append_audit', lambda *a, **kw: None)
+
+    assert kb.cmd_complete('T-INCOMPLETE', '不应完结') is False
+    assert json.loads(tasks_path.read_text(encoding='utf-8')) == original
+
+
 # ── Test: modify_tasks holds file lock ──
 
 
@@ -126,6 +178,73 @@ class TestUpdateTaskSchedulerAtomicity:
         assert result is False
 
 
+class TestDispatchCompletionGuard:
+    """Dispatch must not cross a concurrent terminal-state boundary."""
+
+    def test_dispatch_queue_rejects_completed_task(self, monkeypatch, tmp_path):
+        task = {
+            'id': 'T-DISPATCH-DONE', 'title': '已完成', 'state': 'Done',
+            'org': '皇上', 'completedAt': '2026-04-22T02:00:00Z',
+            '_scheduler': {'enabled': False, 'lastDispatchStatus': 'completed'},
+        }
+        srv, _, tasks_path = _setup_server(monkeypatch, tmp_path, [task])
+        started = []
+
+        class FakeThread:
+            def __init__(self, **kwargs):
+                self.target = kwargs['target']
+
+            def start(self):
+                started.append(self.target)
+
+        monkeypatch.setattr(srv.threading, 'Thread', FakeThread)
+        stale_snapshot = dict(task, state='Zhongshu', org='中书省')
+
+        srv.dispatch_for_state('T-DISPATCH-DONE', stale_snapshot, 'Zhongshu', trigger='test')
+
+        assert started == []
+        assert json.loads(tasks_path.read_text(encoding='utf-8'))[0] == task
+
+    def test_background_dispatch_rechecks_after_completion(self, monkeypatch, tmp_path):
+        task = {
+            'id': 'T-DISPATCH-RACE', 'title': '并发完成', 'state': 'Zhongshu',
+            'org': '中书省',
+            '_scheduler': {'enabled': True, 'lastDispatchStatus': 'idle'},
+        }
+        srv, _, tasks_path = _setup_server(monkeypatch, tmp_path, [task])
+        targets = []
+
+        class FakeThread:
+            def __init__(self, **kwargs):
+                self.target = kwargs['target']
+
+            def start(self):
+                targets.append(self.target)
+
+        monkeypatch.setattr(srv.threading, 'Thread', FakeThread)
+        monkeypatch.setattr(
+            srv.subprocess,
+            'run',
+            lambda *a, **kw: (_ for _ in ()).throw(AssertionError('must not dispatch')),
+        )
+
+        srv.dispatch_for_state('T-DISPATCH-RACE', task, 'Zhongshu', trigger='test')
+        assert len(targets) == 1
+
+        def finish(current):
+            current['state'] = 'Done'
+            current['org'] = '皇上'
+            current['_scheduler']['enabled'] = False
+            current['_scheduler']['lastDispatchStatus'] = 'completed'
+
+        srv.modify_task('T-DISPATCH-RACE', finish)
+        targets[0]()
+
+        updated = json.loads(tasks_path.read_text(encoding='utf-8'))[0]
+        assert updated['state'] == 'Done'
+        assert updated['_scheduler']['lastDispatchStatus'] == 'completed'
+
+
 # ── Test: handle_scheduler_scan uses modify_tasks ──
 
 
@@ -167,6 +286,84 @@ class TestSchedulerScanAtomicity:
         sched = data[0].get('_scheduler', {})
         assert sched['retryCount'] == 1
         assert sched['lastDispatchTrigger'] == 'taizi-scan-retry'
+
+    def test_scan_finalizes_returned_task_without_redispatch(self, monkeypatch, tmp_path):
+        """A completed final reply must heal the task instead of retrying it."""
+        import datetime
+
+        old_ts = (
+            datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=700)
+        ).isoformat()
+        task = {
+            'id': 'T-RETURNED', 'title': '已回奏任务', 'state': 'Zhongshu',
+            'org': '皇上', 'updatedAt': old_ts, 'ready_to_close': True,
+            'todos': [{'id': '1', 'title': '执行', 'status': 'completed'}],
+            'flow_log': [{
+                'at': old_ts, 'from': '太子', 'to': '皇上',
+                'remark': '✅ 回奏皇上：任务已完成',
+            }],
+            '_scheduler': {
+                'enabled': True, 'stallThresholdSec': 600, 'maxRetry': 2,
+                'retryCount': 0, 'escalationLevel': 0, 'autoRollback': True,
+                'lastProgressAt': old_ts, 'stallSince': None,
+                'lastDispatchStatus': 'idle', 'rollbackCount': 0,
+                'snapshot': {'state': 'Taizi', 'org': '太子', 'now': '', 'savedAt': old_ts, 'note': 'init'},
+            },
+        }
+        srv, _, tasks_path = _setup_server(monkeypatch, tmp_path, [task])
+
+        dispatched = []
+        monkeypatch.setattr(srv, 'dispatch_for_state', lambda *a, **kw: dispatched.append((a, kw)))
+        monkeypatch.setattr(srv, 'wake_agent', lambda *a, **kw: dispatched.append((a, kw)))
+
+        result = srv.handle_scheduler_scan(threshold_sec=600)
+
+        assert result['ok'] is True
+        assert result['count'] == 0
+        assert dispatched == []
+        updated = json.loads(tasks_path.read_text(encoding='utf-8'))[0]
+        assert updated['state'] == 'Done'
+        assert updated['org'] == '皇上'
+        assert updated['completedAt']
+        assert updated['_scheduler']['enabled'] is False
+        assert updated['_scheduler']['lastDispatchStatus'] == 'completed'
+
+    def test_scan_rechecks_state_before_retry_side_effect(self, monkeypatch, tmp_path):
+        """A completion committed after scanning must cancel queued dispatch."""
+        import datetime
+
+        old_ts = (
+            datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(seconds=700)
+        ).isoformat()
+        task = {
+            'id': 'T-RACE-COMPLETE', 'title': '扫描并发收口', 'state': 'Zhongshu',
+            'org': '中书省', 'updatedAt': old_ts,
+            '_scheduler': {
+                'enabled': True, 'stallThresholdSec': 600, 'maxRetry': 2,
+                'retryCount': 0, 'escalationLevel': 0,
+                'lastProgressAt': old_ts, 'lastDispatchStatus': 'idle',
+            },
+        }
+        srv, _, _ = _setup_server(monkeypatch, tmp_path, [task])
+        real_load_tasks = srv.load_tasks
+
+        def complete_before_dispatch():
+            current = real_load_tasks()
+            current[0]['state'] = 'Done'
+            current[0]['_scheduler']['enabled'] = False
+            current[0]['_scheduler']['lastDispatchStatus'] = 'completed'
+            return current
+
+        dispatched = []
+        monkeypatch.setattr(srv, 'load_tasks', complete_before_dispatch)
+        monkeypatch.setattr(srv, 'dispatch_for_state', lambda *a, **kw: dispatched.append((a, kw)))
+
+        result = srv.handle_scheduler_scan(threshold_sec=600)
+
+        assert result['count'] == 1
+        assert dispatched == []
 
 
 # ── Test: concurrent modify_task calls don't clobber ──


### PR DESCRIPTION
## 变更描述

Fixes #334.

太子完成最终回奏后，原流程只追加 `flow_log`，没有同步写入 `Done` 和关闭调度器。因此任务超过停滞阈值后仍会被巡检重试并重新派发。

本 PR：

- 新增 `complete` 命令，在同一次文件锁事务中写入结构化回奏记录、`Done`、`completedAt` 和 scheduler 完成态；重复调用保持幂等。
- 将太子的最终回奏流程切换到 `complete`，同时保留普通 `flow` 的原有语义。
- 让 scheduler 对旧版“太子 → 皇上 / ✅ 回奏皇上”记录进行防御性收口，并在锁外派发前重验最新状态，避免并发完成后继续派发。
- 保持现有 todo 完成门禁；未完成 todo 不能被最终收口。

回归测试在原始 `main` SHA `14a2075` 上稳定失败 2 项，应用修复后相同命令 2 项全部通过。

## 变更类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档更新
- [ ] CI / 工程配置

## 检查清单

- [x] 代码已通过 `python3 -m py_compile` 检查
- [ ] 已在本地测试运行 `run_loop.sh`（本修复不依赖 OpenClaw 运行时）
- [ ] 涉及看板的变更已在浏览器中验证（未改变 UI 渲染）
- [x] 更新了相关文档（太子最终回奏命令）

验证结果：

- 核心失败前/通过后回归：2 passed
- 隔离 `OPENCLAW_HOME` 的项目测试：67 passed, 7 deselected
- 7 个排除项均为上游基线失败：2 个旧 E2E 仍假设 `Zhongshu` 可直接 `done`；5 个 symlink 用例未隔离模块级 `OPENCLAW_HOME`
- `python3 -m py_compile scripts/kanban_update.py dashboard/server.py`

## 关联 Issue

Fixes #334
